### PR TITLE
Remove accidental `breakpoint()` calls in examples

### DIFF
--- a/examples/audio-transcription-cli/src/audio_transcription_cli/text_cleaner.py
+++ b/examples/audio-transcription-cli/src/audio_transcription_cli/text_cleaner.py
@@ -104,7 +104,6 @@ class TextCleaner:
         except Exception as e:
             print(f"⚠️ Text cleaning failed: {e}")
             print("📝 Falling back to raw transcription")
-            breakpoint()
             return raw_text
 
     def _get_messages(self, raw_text: str) -> list[dict[str, str]]:

--- a/examples/browser-control/src/browser_control/evaluate.py
+++ b/examples/browser-control/src/browser_control/evaluate.py
@@ -83,7 +83,6 @@ def test_click_in_browsergym(
             error = observation.error if observation.last_action_error else ""
 
             user_prompt = make_user_prompt(goal, step_num, axtree, error)
-            breakpoint()
             messages = [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},

--- a/examples/car-maker-identification/src/car_maker_identification/evaluate.py
+++ b/examples/car-maker-identification/src/car_maker_identification/evaluate.py
@@ -203,6 +203,5 @@ if __name__ == "__main__":
             label = config.label_mapping[sample[config.label_column]]
         except KeyError:
             print("Error mapping label: ", sample[config.label_column])
-            breakpoint()
 
         print("--------------------------------")

--- a/examples/voice-chat/src/voice_chat/audio_example.py
+++ b/examples/voice-chat/src/voice_chat/audio_example.py
@@ -49,7 +49,6 @@ def record(silence_duration: float = 2.0, silence_threshold: float = 0.01):
 
         # Get recorded audio
         audio_data = recorder.stop_recording()
-        breakpoint()
 
         if len(audio_data) == 0:
             print("\nNo audio recorded!")


### PR DESCRIPTION
- Removes stray breakpoint() statements that can halt execution in non-interactive runs.
- No functional behavior change besides avoiding debugger stops.