### PR TITLE
Fix llama binary path validation in audio transcription downloader

### DIFF
--- a/examples/audio-transcription-cli/src/audio_transcription_cli/model_downloader.py
+++ b/examples/audio-transcription-cli/src/audio_transcription_cli/model_downloader.py
@@ -143,7 +143,7 @@ class ModelDownloader:
         if not self.llama_cpp_binary_dir.exists():
             return False
 
-        if not Path(self.llama_binary_name / self.llama_cpp_binary_dir).exists():
+        if not (self.llama_cpp_binary_dir / self.llama_binary_name).exists():   
             return False
         
         return True


### PR DESCRIPTION
- Fixes incorrect path join in `_validate_existing_download()` so existing downloads validate correctly.
- Aligns validation path with `get_model_command()`.