### PR TITLE
Fix audio-car-cockpit: add missing Makefile dependency for runner download

### DIFF
--- a/examples/audio-car-cockpit/Makefile
+++ b/examples/audio-car-cockpit/Makefile
@@ -103,8 +103,8 @@ $(ZIP):
 	uv run --with "huggingface_hub" hf download "LiquidAI/LFM2.5-Audio-1.5B-GGUF" --local-dir ./ $@
 	unzip -q -o $@
 
-llama-liquid-audio/llama-liquid-audio-server:  ## Download pre-built llama-liquid-audio-server
-	ln -s $(DIR) llama-liquid-audio
+llama-liquid-audio/llama-liquid-audio-server: $(ZIP)  ## Download pre-built llama-liquid-audio-server
+	ln -sf $(DIR) llama-liquid-audio
 	@# Sanity check
 	./llama-liquid-audio/llama-liquid-audio-server --version
 


### PR DESCRIPTION
## Summary

- Add missing `$(ZIP)` dependency to the `llama-liquid-audio/llama-liquid-audio-server` target so the runner binary is downloaded before the symlink is created
- Use `ln -sf` instead of `ln -s` so the target is idempotent (doesn't fail when the symlink already exists)

Without this fix, following the README quick start instructions fails because `make audioserver` tries to symlink to a directory (`llama-liquid-audio-macos-arm64`) that was never downloaded/extracted. The `$(ZIP)` target (which downloads and unzips the runner) was only reachable via the `llama-liquid-audio-runner` phony target, which nothing in the `audioserver` dependency chain referenced.

## Test plan

- [ ] Clean checkout, follow README quick start (`make setup && make LFM2.5-Audio-1.5B-GGUF LFM2-1.2B-Tool-GGUF && make -j2 audioserver serve`) — should now succeed without manual intervention
- [ ] Re-running `make audioserver` after a previous run should not fail on `ln -s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)