### PR TITLE
Include WebML Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Open-source projects built by the community showcasing LFMs with real use cases.
 | Chat with LEAP SDK | LEAP SDK integration for React Native | [Code](https://github.com/glody007/expo-leap-sdk) |
 | Private Summarizer | 100% local text summarization with multi-language support | [Code](https://github.com/Private-Intelligence/private_summarizer) |
 | Tiny-MoA | Mixture of Agents on CPU with LFM2.5 Brain (1.2B) | [Code](https://github.com/gyunggyung/Tiny-MoA) |
+| LFM-2.5 JP on Web | LFM2.5 1.2B parameter Japanese language model running locally in the browser with WebGPU, using Transformers.js and ONNX Runtime on Web | [Code](https://github.com/sitammeur/lfm2.5-jp-web) |
+| LFM-2.5 Thinking on Web | LFM2.5 1.2B parameter reasoning language model running locally in the browser with WebGPU, using Transformers.js and ONNX Runtime Web | [Code](https://github.com/sitammeur/lfm2.5-thinking-web) |
 
 ## 🕐 Technical Deep Dives
 


### PR DESCRIPTION
Adding WebML examples for running the LFM 2.5 thinking model and Japanese (JP) in the browser using WebGPU, transformers.js, and ONNX Runtime Web.

cc: @Paulescu 