### PR TITLE
Add grosme to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Open-source projects built by the community showcasing LFMs with real use cases.
 | LFM2.5 Mobile Actions | LoRA fine-tuned LFM2.5-1.2B that translates natural language into Android OS function calls for on-device mobile action recognition | [Code](https://github.com/Mandark-droid/LFM2.5-1.2B-Instruct-mobile-actions) |
 | SFT + DPO Fine-tuning | Teaching a 1.2B Model to be a Grumpy Italian Chef: SFT + DPO Fine-Tuning with Unsloth | [Code](https://github.com/benitomartin/grumpy-chef-finetuning-dpo) |
 | Tauri Plugin LEAP AI | Tauri plugin to integrate LEAP and Liquid LFMs into desktop and mobile apps built with Tauri | [Crate](https://crates.io/crates/tauri-plugin-leap-ai) |
+| grosme | CLI grocery assistant that reads Apple Notes lists and finds Walmart product matches using LFM-2.5 tool-calling agent via Ollama | [Code](https://github.com/earl562/grosme) |
 
 ## 🕐 Technical Deep Dives
 


### PR DESCRIPTION
## Summary
- Adds [grosme](https://github.com/earl562/grosme) to the Community Projects table

## About grosme
A macOS CLI that reads grocery lists from Apple Notes and finds matching Walmart products, powered by LFM-2.5 Thinking (1.2B) running locally through Ollama as a tool-calling agent.

Features:
- Agent loop using Ollama's tool-calling API with LFM-2.5 Thinking
- Stealth browser scraping of Walmart search results with relevance scoring
- Apple Notes integration via memo CLI
- Apple Calendar event creation for shopping reminders
- Runs entirely on-device — no cloud, no API keys required
- 90% accuracy on a 20-item benchmark suite

Repo: https://github.com/earl562/grosme