### PR TITLE
Add CI/CD for LocalCowork macOS releases (.dmg)

### DIFF
--- a/.github/workflows/release-localcowork.yml
+++ b/.github/workflows/release-localcowork.yml
@@ -15,6 +15,7 @@ defaults:
 jobs:
   build-macos:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
@@ -30,10 +31,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: examples/localcowork/src-tauri
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -43,16 +49,19 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli
 
-      - name: Install frontend dependencies
-        run: npm ci
-
-      - name: Install MCP server dependencies
+      - name: Install all dependencies
         run: |
+          # Root workspace (includes @tauri-apps/api, zustand, react, etc.)
+          npm install
+          # TypeScript MCP servers
           for dir in mcp-servers/filesystem mcp-servers/calendar mcp-servers/email mcp-servers/task mcp-servers/data mcp-servers/audit mcp-servers/clipboard mcp-servers/system; do
             if [ -f "$dir/package.json" ]; then
-              cd "$dir" && npm ci && cd -
+              (cd "$dir" && npm install)
             fi
           done
+
+      - name: Build frontend
+        run: npm run build
 
       - name: Build Tauri app
         run: cargo tauri build --target ${{ matrix.target }}
@@ -63,9 +72,7 @@ jobs:
       - name: Prepare release artifacts
         run: |
           mkdir -p release-artifacts
-          # Find and copy .dmg files
           find src-tauri/target/${{ matrix.target }}/release/bundle -name "*.dmg" -exec cp {} release-artifacts/ \;
-          # Find and copy .app.tar.gz files (for Homebrew)
           find src-tauri/target/${{ matrix.target }}/release/bundle -name "*.app.tar.gz" -exec cp {} release-artifacts/ \;
           find src-tauri/target/${{ matrix.target }}/release/bundle -name "*.app.tar.gz.sig" -exec cp {} release-artifacts/ \;
           ls -lh release-artifacts/
@@ -105,7 +112,12 @@ jobs:
           body: |
             ## LocalCowork v${{ steps.version.outputs.version }}
 
-            On-device AI assistant powered by LFM2-24B-A2B. No cloud, no data leaving your machine.
+            On-device AI agent powered by LFM2-24B-A2B from Liquid AI.
+            Runs entirely on-device — no cloud, no data leaving your machine.
+
+            ### Requirements
+            - Apple Silicon Mac (M1 Pro or later) with 16+ GB unified memory
+            - macOS 12 (Monterey) or later
 
             ### Install via Homebrew
             ```bash
@@ -113,14 +125,20 @@ jobs:
             brew install --cask localcowork
             ```
 
-            ### Prerequisites
-            - llama.cpp: `brew install llama.cpp`
-            - LFM2-24B-A2B model (~14 GB): see README for download instructions
+            ### Model download (~14 GB)
+            ```bash
+            pip3 install huggingface-hub
+            huggingface-cli download LiquidAI/LFM2-24B-A2B-GGUF \
+              LFM2-24B-A2B-Q4_K_M.gguf --local-dir ~/Models
+            ```
 
             ### Checksums
             ```
             $(cat artifacts/checksums.txt)
             ```
+
+            ---
+            Community package of [Liquid AI's open-source project](https://github.com/Liquid4All/cookbook/tree/main/examples/localcowork) (MIT license).
           files: artifacts/*
           draft: false
           prerelease: false


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds and releases LocalCowork as macOS `.dmg` installers for both arm64 and x86_64, triggered by `localcowork-v*` tags.

This enables distribution via Homebrew and direct download — making it much easier for people to try LocalCowork without cloning the repo and building from source.

## What's included

- `.github/workflows/release-localcowork.yml` — builds Tauri app for both architectures on `macos-14` runners, creates a GitHub Release with `.dmg` files and SHA256 checksums
- Rust build cache for faster CI runs
- Frontend built explicitly before `cargo tauri build`

## Motivation

LocalCowork is a great showcase of LFM2-24B-A2B's tool-calling capabilities, but the current setup requires Node.js, Python 3.12, Rust, and Tauri CLI just to try it. Pre-built `.dmg` releases would lower the barrier significantly.

With official signed releases, LocalCowork could also be distributed through [Homebrew](https://brew.sh) — we've already prototyped a community tap at [pierretokns/homebrew-localcowork](https://github.com/pierretokns/homebrew-localcowork) that installs all dependencies (llama.cpp, node, python, tesseract) and shows the model download instructions.

## Tested

- ✅ arm64 build passes on `macos-14` runner
- ✅ x86_64 build passes on `macos-14` runner
- ✅ GitHub Release created with `.dmg` artifacts and checksums
- ✅ Example release: https://github.com/pierretokns/cookbook/releases/tag/localcowork-v0.1.1

## Related

See #52 for the full discussion about Homebrew distribution and what's needed for official `brew.sh` inclusion.

## Test plan

- [x] Both architecture builds complete successfully
- [x] `.dmg` files are valid and contain `LocalCowork.app`
- [x] Release is created with correct checksums
- [ ] Code signing with Apple Developer ID (would need secrets configured)