### PR TITLE
feat(localcowork): Ubuntu support with ROCm GPU auto-detection

### DIFF
--- a/examples/localcowork/.gitignore
+++ b/examples/localcowork/.gitignore
@@ -53,6 +53,10 @@ scripts/sync-to-cookbook.sh
 # ─── Demo scripts (personal, not shared) ─────────────────────────────────
 docs/demo/demo-script-4min.md
 
+# ─── Build artifacts ──────────────────────────────────────────────────────
+llama.cpp/
+llama-server
+
 # ─── Environment ─────────────────────────────────────────────────────────
 .env
 .env.local

--- a/examples/localcowork/Makefile
+++ b/examples/localcowork/Makefile
@@ -1,0 +1,102 @@
+.PHONY: help all setup serve clean install-deps
+
+all: help
+
+help:  ## Show commands
+	@echo "Default to \`help\`. Other targets:"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-24s\033[0m %s\n", $$1, $$2}'
+
+
+# ┌──────────────────────────────────────────────────────────┐
+# │              Platform detection and ROCm                 │
+# └──────────────────────────────────────────────────────────┘
+
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+ifdef CPU
+  HAS_ROCM :=
+else
+  HAS_ROCM := $(shell rocm-smi --showproductname 2>/dev/null | grep "Card Series" >/dev/null && echo 1)
+endif
+
+LLAMA_CPP_REPO   := https://github.com/ggml-org/llama.cpp.git
+LLAMA_CPP_COMMIT := d03c45c9c56795af8b0e899762bf266c14fd2028
+
+
+# ┌──────────────────────────────────────────────────────────┐
+# │           Build configuration (ROCm vs CPU)              │
+# └──────────────────────────────────────────────────────────┘
+
+ifdef HAS_ROCM
+  $(info ROCm detected — building with HIP GPU acceleration)
+
+  _DETECTED_HIP_ARCH := $(shell rocm-smi --showproductname 2>/dev/null | grep -oP 'gfx\w+' | head -1)
+  HIP_ARCH   ?= $(or $(_DETECTED_HIP_ARCH),gfx1150)
+  $(info Using HIP_ARCH=$(HIP_ARCH))
+  CMAKE_ARGS := -DGGML_HIP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_HIP_ARCHITECTURES="$(HIP_ARCH)"
+  GPU_FLAGS  := --n-gpu-layers 99
+
+else
+  ifdef CPU
+    $(info CPU=1 set — forcing CPU-only build)
+  else
+    $(info ROCm not found — building CPU-only)
+  endif
+
+  CMAKE_ARGS := -DBUILD_SHARED_LIBS=OFF -DLLAMA_CURL=ON
+  GPU_FLAGS  :=
+
+endif
+
+
+# ┌──────────────────────────────────────────────────────────┐
+# │                Build llama.cpp from source                │
+# └──────────────────────────────────────────────────────────┘
+
+llama.cpp:
+	git clone $(LLAMA_CPP_REPO) && \
+		cd llama.cpp && \
+		git checkout $(LLAMA_CPP_COMMIT)
+
+install-deps:  ## Install system dependencies required to build llama-server
+ifeq ($(UNAME_S),Darwin)
+	@echo "On macOS, install Xcode Command Line Tools and cmake via Homebrew:"
+	@echo "  xcode-select --install"
+	@echo "  brew install cmake"
+else ifeq ($(UNAME_S),Linux)
+	sudo apt install -y build-essential cmake libssl-dev libcurl4-openssl-dev
+else
+	$(error install-deps: unsupported OS $(UNAME_S))
+endif
+
+llama.cpp/build/bin/llama-server: llama.cpp
+ifeq ($(UNAME_S),Linux)
+	@dpkg -s libssl-dev >/dev/null 2>&1 || \
+		(echo "Error: libssl-dev not found — llama-server would build without HTTPS support." \
+		     "Run 'make install-deps' first." && exit 1)
+endif
+	cd llama.cpp && \
+		cmake -B build $(CMAKE_ARGS) && \
+		cmake --build build --config Release -t llama-server -j 8
+
+llama-server: llama.cpp/build/bin/llama-server  ## Build llama-server (auto-detects ROCm)
+	cp llama.cpp/build/bin/llama-server $@
+	@echo ""
+	@echo "✅ llama-server built successfully"
+ifdef HAS_ROCM
+	@echo "   GPU acceleration: HIP ($(HIP_ARCH))"
+else
+	@echo "   GPU acceleration: none (CPU-only)"
+endif
+	@echo "   Binary: $(PWD)/llama-server"
+	@echo ""
+	@echo "   Add to PATH:  ln -s $(PWD)/llama-server ~/.local/bin/llama-server"
+
+
+# ┌──────────────────────────────────────────────────────────┐
+# │                        Utilities                         │
+# └──────────────────────────────────────────────────────────┘
+
+clean:  ## Remove build artifacts (llama.cpp clone and binary)
+	rm -rf llama.cpp llama-server

--- a/examples/localcowork/README.md
+++ b/examples/localcowork/README.md
@@ -221,42 +221,13 @@ Tool definitions live in [`docs/mcp-tool-registry.yaml`](docs/mcp-tool-registry.
 
 Optional: [Ollama](https://ollama.ai) (alternative runtime), [Tesseract](https://github.com/tesseract-ocr/tesseract) (fallback OCR).
 
-### macOS
+All prerequisites are installed automatically by `./scripts/setup-dev.sh`, which detects your OS (macOS or Ubuntu/Debian) and installs the required packages. On macOS it uses Homebrew; on Ubuntu it uses apt and installs Tauri GTK/WebKit dependencies, Rust, Node.js, cmake, and adjusts the inotify watcher limit.
+
+After setup, build `llama-server` (Linux only — macOS uses `brew install llama.cpp`):
 
 ```bash
-brew install llama.cpp cmake node python3
-# Xcode Command Line Tools required:
-xcode-select --install
-```
-
-### Ubuntu / Debian
-
-```bash
-# Node.js 22+
-curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-sudo apt-get install -y nodejs
-
-# Python venv support
-sudo apt install -y python3-venv
-
-# Rust
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source ~/.cargo/env
-
-# Tauri system dependencies (GTK, WebKit)
-sudo apt install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-    librsvg2-dev patchelf libssl-dev
-
-# Build dependencies for llama.cpp
-make install-deps
-
-# Build llama-server (auto-detects ROCm GPU, falls back to CPU)
-make llama-server
-# To force CPU-only build: make CPU=1 llama-server
-
-# Increase file watcher limit (required for Vite dev server)
-echo "fs.inotify.max_user_watches=524288" | sudo tee -a /etc/sysctl.d/99-inotify.conf
-sudo sysctl -p /etc/sysctl.d/99-inotify.conf
+make llama-server            # auto-detects ROCm GPU, falls back to CPU
+make CPU=1 llama-server      # force CPU-only build
 ```
 
 ## Tests

--- a/examples/localcowork/README.md
+++ b/examples/localcowork/README.md
@@ -4,7 +4,7 @@
 
 **Tool-calling that actually feels instant on a laptop.**
 
-Building a local AI agent sounds great until you try to use one all day. The hard part isn't getting a model to understand you -- it's getting it to choose the right tool and do it fast enough that the experience feels interactive. This is where [LFM2-24B-A2B](https://huggingface.co/LiquidAI/LFM2-24B-A2B-Preview) shines: it's designed for tool dispatch on consumer hardware, where latency and memory aren't abstract constraints -- they decide whether your agent is a product or a demo.
+Building a local AI agent sounds great until you try to use one all day. The hard part isn't getting a model to understand you -- it's getting it to choose the right tool and do it fast enough that the experience feels interactive. This is where [LFM2-24B-A2B](https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF) shines: it's designed for tool dispatch on consumer hardware, where latency and memory aren't abstract constraints -- they decide whether your agent is a product or a demo.
 
 LocalCowork is a desktop AI agent that runs entirely on-device. No cloud APIs, no data leaving your machine. The model calls pre-built tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP), and every tool execution is logged to a local audit trail.
 
@@ -117,16 +117,17 @@ Full study with 8 models, 150+ scenarios, and 12 failure modes: [`docs/model-ana
 
 ```bash
 # 1. Clone and set up
-git clone <repo-url> && cd localCoWork
+git clone <repo-url> && cd examples/localcowork/
 ./scripts/setup-dev.sh
 
-# 2. Download LFM2-24B-A2B (~14 GB, requires HuggingFace access)
-#    Request access: https://huggingface.co/LiquidAI/LFM2-24B-A2B-Preview
+# 2. Download LFM2-24B-A2B (~14 GB)
+#    https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF
+source .venv/bin/activate
 pip install huggingface-hub
 python3 -c "
 from huggingface_hub import hf_hub_download
-hf_hub_download('LiquidAI/LFM2-24B-A2B-Preview',
-                'LFM2-24B-A2B-Preview-Q4_K_M.gguf',
+hf_hub_download('LiquidAI/LFM2-24B-A2B-GGUF',
+                'LFM2-24B-A2B-Q4_K_M.gguf',
                 local_dir='$HOME/Projects/_models/')
 "
 
@@ -211,9 +212,43 @@ Tool definitions live in [`docs/mcp-tool-registry.yaml`](docs/mcp-tool-registry.
 | Node.js | 20+ | TypeScript MCP servers, React frontend |
 | Python | 3.11+ | Python MCP servers (document, OCR, security, etc.) |
 | Rust | 1.77+ | Tauri backend, Agent Core |
-| llama.cpp | latest | Serves LFM2 models (`brew install llama.cpp`) |
+| llama.cpp | latest | Serves LFM2 models |
 
 Optional: [Ollama](https://ollama.ai) (alternative runtime), [Tesseract](https://github.com/tesseract-ocr/tesseract) (fallback OCR).
+
+### macOS
+
+```bash
+brew install llama.cpp cmake node python3
+# Xcode Command Line Tools required:
+xcode-select --install
+```
+
+### Ubuntu / Debian
+
+```bash
+# Node.js 22+
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Python venv support
+sudo apt install -y python3-venv
+
+# Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source ~/.cargo/env
+
+# Tauri system dependencies (GTK, WebKit)
+sudo apt install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+    librsvg2-dev patchelf libssl-dev
+
+# llama.cpp (build from source for GPU support, or use a pre-built binary)
+# See https://github.com/ggml-org/llama.cpp for build instructions
+
+# Increase file watcher limit (required for Vite dev server)
+echo "fs.inotify.max_user_watches=524288" | sudo tee -a /etc/sysctl.d/99-inotify.conf
+sudo sysctl -p /etc/sysctl.d/99-inotify.conf
+```
 
 ## Tests
 

--- a/examples/localcowork/README.md
+++ b/examples/localcowork/README.md
@@ -120,7 +120,12 @@ Full study with 8 models, 150+ scenarios, and 12 failure modes: [`docs/model-ana
 git clone <repo-url> && cd examples/localcowork/
 ./scripts/setup-dev.sh
 
-# 2. Download LFM2-24B-A2B (~14 GB)
+# 2. Build llama-server (auto-detects ROCm GPU on Linux)
+#    macOS: brew install llama.cpp (skip this step)
+#    Linux: builds from source with GPU acceleration if available
+make llama-server
+
+# 3. Download LFM2-24B-A2B (~14 GB)
 #    https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF
 source .venv/bin/activate
 pip install huggingface-hub
@@ -131,10 +136,10 @@ hf_hub_download('LiquidAI/LFM2-24B-A2B-GGUF',
                 local_dir='$HOME/Projects/_models/')
 "
 
-# 3. Start the model server
+# 4. Start the model server
 ./scripts/start-model.sh
 
-# 4. Launch the app (in another terminal)
+# 5. Launch the app (in another terminal)
 cargo tauri dev
 ```
 
@@ -242,8 +247,12 @@ source ~/.cargo/env
 sudo apt install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
     librsvg2-dev patchelf libssl-dev
 
-# llama.cpp (build from source for GPU support, or use a pre-built binary)
-# See https://github.com/ggml-org/llama.cpp for build instructions
+# Build dependencies for llama.cpp
+make install-deps
+
+# Build llama-server (auto-detects ROCm GPU, falls back to CPU)
+make llama-server
+# To force CPU-only build: make CPU=1 llama-server
 
 # Increase file watcher limit (required for Vite dev server)
 echo "fs.inotify.max_user_watches=524288" | sudo tee -a /etc/sysctl.d/99-inotify.conf

--- a/examples/localcowork/scripts/setup-dev.sh
+++ b/examples/localcowork/scripts/setup-dev.sh
@@ -10,51 +10,130 @@ echo "  LocalCowork — Dev Environment Setup"
 echo "═══════════════════════════════════════════════════"
 echo ""
 
-# ── Ensure common tool paths are on PATH ─────────────────────────────────
+# ── Detect OS ─────────────────────────────────────────────────────────────
 
-# /usr/local/bin — where Ollama and other macOS tools live
-[[ ":$PATH:" != *":/usr/local/bin:"* ]] && export PATH="/usr/local/bin:$PATH"
+OS="$(uname -s)"
+echo "Detected OS: $OS"
+echo ""
 
-# Cargo / Rust
-if ! command -v cargo &> /dev/null; then
-    if [ -f "$HOME/.cargo/env" ]; then
-        # shellcheck source=/dev/null
-        source "$HOME/.cargo/env"
-    elif [ -x "$HOME/.cargo/bin/cargo" ]; then
-        export PATH="$HOME/.cargo/bin:$PATH"
-    fi
-fi
+# ── Install system prerequisites ──────────────────────────────────────────
 
-# ── Check prerequisites ────────────────────────────────────────────────────
+echo "Installing system prerequisites..."
 
-check_command() {
-    if ! command -v "$1" &> /dev/null; then
-        echo "❌ $1 is not installed. $2"
+if [ "$OS" = "Darwin" ]; then
+    # ── macOS ──
+    if ! command -v brew &> /dev/null; then
+        echo "❌ Homebrew not found. Install from https://brew.sh"
         exit 1
-    else
-        echo "✅ $1 found: $(command -v "$1")"
     fi
-}
 
-check_optional_command() {
-    if ! command -v "$1" &> /dev/null; then
-        echo "⚠️  $1 is not installed (optional). $2"
-    else
-        echo "✅ $1 found: $(command -v "$1")"
+    if ! command -v node &> /dev/null; then
+        echo "  Installing Node.js..."
+        brew install node
     fi
-}
 
-echo "Checking prerequisites..."
-check_command "node" "Install Node.js 20+ from https://nodejs.org"
-check_command "npm" "Comes with Node.js"
-check_command "python3" "Install Python 3.11+ from https://python.org"
-if ! python3 -m venv --help &> /dev/null; then
-    PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-    echo "❌ python3-venv is not installed. Run: sudo apt install -y python${PY_VER}-venv"
+    if ! command -v python3 &> /dev/null; then
+        echo "  Installing Python..."
+        brew install python3
+    fi
+
+    if ! command -v cargo &> /dev/null; then
+        echo "  Installing Rust..."
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source "$HOME/.cargo/env"
+    fi
+
+    if ! command -v cmake &> /dev/null; then
+        echo "  Installing cmake..."
+        brew install cmake
+    fi
+
+    if ! xcode-select -p &> /dev/null; then
+        echo "  Installing Xcode Command Line Tools..."
+        xcode-select --install
+        echo "  ⚠️  Please complete the Xcode CLT install dialog, then re-run this script."
+        exit 1
+    fi
+
+elif [ "$OS" = "Linux" ]; then
+    # ── Ubuntu / Debian ──
+    if ! command -v apt-get &> /dev/null; then
+        echo "❌ apt-get not found. This script supports macOS and Debian/Ubuntu."
+        exit 1
+    fi
+
+    NEEDS_APT=()
+
+    if ! command -v node &> /dev/null; then
+        echo "  Installing Node.js 22..."
+        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+    fi
+
+    if ! python3 -m venv --help &> /dev/null; then
+        PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        NEEDS_APT+=("python${PY_VER}-venv")
+    fi
+
+    for pkg in build-essential cmake libssl-dev libcurl4-openssl-dev \
+               libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+               librsvg2-dev patchelf; do
+        if ! dpkg -s "$pkg" &> /dev/null; then
+            NEEDS_APT+=("$pkg")
+        fi
+    done
+
+    if [ ${#NEEDS_APT[@]} -gt 0 ]; then
+        echo "  Installing: ${NEEDS_APT[*]}"
+        sudo apt-get install -y "${NEEDS_APT[@]}"
+    fi
+
+    if ! command -v cargo &> /dev/null; then
+        if [ -f "$HOME/.cargo/env" ]; then
+            source "$HOME/.cargo/env"
+        else
+            echo "  Installing Rust..."
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            source "$HOME/.cargo/env"
+        fi
+    fi
+
+    # Increase inotify watcher limit for Vite dev server
+    if [ "$(cat /proc/sys/fs/inotify/max_user_watches 2>/dev/null)" -lt 524288 ] 2>/dev/null; then
+        echo "  Increasing inotify watcher limit..."
+        echo "fs.inotify.max_user_watches=524288" | sudo tee -a /etc/sysctl.d/99-inotify.conf > /dev/null
+        sudo sysctl -p /etc/sysctl.d/99-inotify.conf > /dev/null
+    fi
+
+else
+    echo "❌ Unsupported OS: $OS (supported: macOS, Linux/Ubuntu)"
     exit 1
 fi
-check_command "cargo" "Install Rust from https://rustup.rs"
-check_optional_command "ollama" "Install Ollama from https://ollama.ai (needed for model tests)"
+
+# ── Ensure common tool paths are on PATH ─────────────────────────────────
+
+[[ ":$PATH:" != *":/usr/local/bin:"* ]] && export PATH="/usr/local/bin:$PATH"
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
+# ── Verify prerequisites ─────────────────────────────────────────────────
+
+echo ""
+echo "Verifying prerequisites..."
+
+check_ok() {
+    if command -v "$1" &> /dev/null; then
+        echo "✅ $1 found: $(command -v "$1")"
+    else
+        echo "❌ $1 not found after install attempt. $2"
+        exit 1
+    fi
+}
+
+check_ok "node" "Install Node.js 20+ from https://nodejs.org"
+check_ok "npm" "Comes with Node.js"
+check_ok "python3" "Install Python 3.11+ from https://python.org"
+check_ok "cargo" "Install Rust from https://rustup.rs"
+check_ok "cmake" "Install cmake"
 
 echo ""
 
@@ -213,11 +292,18 @@ else
 fi
 
 # Check for llama-server (required to serve LFM2 models)
-if command -v llama-server &> /dev/null; then
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -x "$SCRIPT_DIR/llama-server" ]; then
+    echo "✅ llama-server found: $SCRIPT_DIR/llama-server"
+elif command -v llama-server &> /dev/null; then
     echo "✅ llama-server found: $(command -v llama-server)"
 else
-    echo "⚠️  llama-server not found (needed to serve LFM2 models)"
-    echo "    Install via: brew install llama.cpp"
+    echo "⚠️  llama-server not found"
+    if [ "$OS" = "Darwin" ]; then
+        echo "    Install via: brew install llama.cpp"
+    else
+        echo "    Build via:   make llama-server  (auto-detects ROCm GPU)"
+    fi
 fi
 
 # Alternative: Ollama with GPT-OSS-20B (optional, for development/comparison)
@@ -268,12 +354,15 @@ echo "  Setup Complete!"
 echo "═══════════════════════════════════════════════════"
 echo ""
 echo "Next steps:"
-echo "  1. Start model server:  ./scripts/start-model.sh"
-echo "  2. Start dev server:    cargo tauri dev  (in another terminal)"
-echo "  3. Run tests:           npm test"
-echo "  4. Validate servers:    ./scripts/validate-mcp-servers.sh"
-echo "  5. Check progress:      (in Claude Code) /progress"
+if [ ! -x "$SCRIPT_DIR/llama-server" ] && ! command -v llama-server &> /dev/null; then
+    echo "  1. Build llama-server:  make llama-server  (auto-detects ROCm GPU)"
+    echo "  2. Download model:      see README.md"
+    echo "  3. Start model server:  ./scripts/start-model.sh"
+    echo "  4. Start dev server:    cargo tauri dev  (in another terminal)"
+else
+    echo "  1. Start model server:  ./scripts/start-model.sh"
+    echo "  2. Start dev server:    cargo tauri dev  (in another terminal)"
+fi
 echo ""
 echo "  Note: The model server must be running before 'cargo tauri dev'."
-echo "  See README.md for alternative model setups (Ollama, vision model)."
 echo ""

--- a/examples/localcowork/scripts/setup-dev.sh
+++ b/examples/localcowork/scripts/setup-dev.sh
@@ -48,6 +48,11 @@ echo "Checking prerequisites..."
 check_command "node" "Install Node.js 20+ from https://nodejs.org"
 check_command "npm" "Comes with Node.js"
 check_command "python3" "Install Python 3.11+ from https://python.org"
+if ! python3 -m venv --help &> /dev/null; then
+    PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+    echo "❌ python3-venv is not installed. Run: sudo apt install -y python${PY_VER}-venv"
+    exit 1
+fi
 check_command "cargo" "Install Rust from https://rustup.rs"
 check_optional_command "ollama" "Install Ollama from https://ollama.ai (needed for model tests)"
 
@@ -187,7 +192,7 @@ echo "  Models directory: $MODELS_DIR"
 echo ""
 
 # Primary model: LFM2-24B-A2B (production, 80% tool-calling accuracy)
-MAIN_MODEL="LFM2-24B-A2B-Preview-Q4_K_M.gguf"
+MAIN_MODEL="LFM2-24B-A2B-Q4_K_M.gguf"
 if [ -f "$MODELS_DIR/$MAIN_MODEL" ]; then
     MAIN_SIZE=$(du -h "$MODELS_DIR/$MAIN_MODEL" | cut -f1)
     echo "✅ LFM2-24B-A2B found ($MAIN_SIZE)"
@@ -195,12 +200,12 @@ else
     echo "❌ LFM2-24B-A2B not found — this is the primary production model"
     echo ""
     echo "   Download from HuggingFace (gated — request access first):"
-    echo "   https://huggingface.co/LiquidAI/LFM2-24B-A2B-Preview"
+    echo "   https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF"
     echo ""
     echo "   pip install huggingface-hub"
     echo "   python3 -c \""
     echo "     from huggingface_hub import hf_hub_download"
-    echo "     hf_hub_download('LiquidAI/LFM2-24B-A2B-Preview',"
+    echo "     hf_hub_download('LiquidAI/LFM2-24B-A2B-GGUF',"
     echo "                     '$MAIN_MODEL',"
     echo "                     local_dir='$MODELS_DIR')"
     echo "   \""

--- a/examples/localcowork/scripts/start-model.sh
+++ b/examples/localcowork/scripts/start-model.sh
@@ -51,22 +51,25 @@ for arg in "$@"; do
     esac
 done
 
-# ── Check llama-server ───────────────────────────────────────────────────────
+# ── Find llama-server ────────────────────────────────────────────────────────
 
-if ! command -v llama-server &> /dev/null; then
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LLAMA_SERVER=""
+
+if [ -x "$SCRIPT_DIR/llama-server" ]; then
+    LLAMA_SERVER="$SCRIPT_DIR/llama-server"
+elif command -v llama-server &> /dev/null; then
+    LLAMA_SERVER="$(command -v llama-server)"
+else
     echo "❌ llama-server not found."
     echo ""
-    echo "Install via Homebrew (macOS):"
-    echo "  brew install llama.cpp"
+    echo "Build with:  make llama-server  (auto-detects ROCm GPU)"
     echo ""
-    echo "Or build from source:"
-    echo "  git clone https://github.com/ggml-org/llama.cpp"
-    echo "  cd llama.cpp && cmake -B build && cmake --build build --config Release"
-    echo "  # Binary at: build/bin/llama-server"
+    echo "Or install via Homebrew (macOS):  brew install llama.cpp"
     exit 1
 fi
 
-echo "✅ llama-server found: $(command -v llama-server)"
+echo "✅ llama-server found: $LLAMA_SERVER"
 
 # ── Check model files ────────────────────────────────────────────────────────
 
@@ -140,7 +143,7 @@ echo "  API:     http://localhost:$MAIN_PORT/v1"
 echo ""
 
 # Start main model in background
-llama-server \
+"$LLAMA_SERVER" \
     --model "$MAIN_PATH" \
     --port "$MAIN_PORT" \
     --ctx-size "$MAIN_CTX" \
@@ -173,7 +176,7 @@ if [ "$START_VISION" = true ] && [ -f "$VISION_PATH" ] && [ -f "$MMPROJ_PATH" ];
     echo "  Starting LFM2.5-VL-1.6B on port $VISION_PORT"
     echo "═══════════════════════════════════════════════════"
 
-    llama-server \
+    "$LLAMA_SERVER" \
         --model "$VISION_PATH" \
         --mmproj "$MMPROJ_PATH" \
         --port "$VISION_PORT" \

--- a/examples/localcowork/scripts/start-model.sh
+++ b/examples/localcowork/scripts/start-model.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 MODELS_DIR="${LOCALCOWORK_MODELS_DIR:-$HOME/Projects/_models}"
 
 # Main model (LFM2-24B-A2B)
-MAIN_MODEL="LFM2-24B-A2B-Preview-Q4_K_M.gguf"
+MAIN_MODEL="LFM2-24B-A2B-Q4_K_M.gguf"
 MAIN_PORT=8080
 MAIN_CTX=32768
 
@@ -85,13 +85,13 @@ else
     echo "❌ Main model not found: $MAIN_PATH"
     echo ""
     echo "   Download LFM2-24B-A2B from HuggingFace (gated — request access first):"
-    echo "   https://huggingface.co/LiquidAI/LFM2-24B-A2B-Preview"
+    echo "   https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF"
     echo ""
     echo "   pip install huggingface-hub"
     echo "   python3 -c \""
     echo "     from huggingface_hub import hf_hub_download"
-    echo "     hf_hub_download('LiquidAI/LFM2-24B-A2B-Preview',"
-    echo "                     'LFM2-24B-A2B-Preview-Q4_K_M.gguf',"
+    echo "     hf_hub_download('LiquidAI/LFM2-24B-A2B-GGUF',"
+    echo "                     'LFM2-24B-A2B-Q4_K_M.gguf',"
     echo "                     local_dir='$MODELS_DIR')"
     echo "   \""
     if [ "$CHECK_ONLY" = true ]; then
@@ -145,7 +145,7 @@ llama-server \
     --port "$MAIN_PORT" \
     --ctx-size "$MAIN_CTX" \
     --n-gpu-layers 99 \
-    --flash-attn &
+    --flash-attn on &
 
 MAIN_PID=$!
 echo "  PID: $MAIN_PID"


### PR DESCRIPTION
## Summary

- **Ubuntu support**: setup-dev.sh now detects the OS (macOS or Ubuntu/Debian) and automatically installs all system prerequisites (Node.js, Python venv, Rust, cmake, Tauri GTK/WebKit deps, inotify watcher limit)
- **Upgraded model from Preview to release**: Updated all references from the gated `LFM2-24B-A2B-Preview` to the public `LFM2-24B-A2B-GGUF` repo. Resolves https://github.com/Liquid4All/cookbook/issues/75
- **GPU-accelerated llama.cpp build**: Added a Makefile that builds llama-server from source with automatic ROCm GPU detection via `rocm-smi`, falling back to CPU. Supports `make CPU=1` override
- **Improved usability**: setup-dev.sh handles all prerequisites automatically — the README Prerequisites section is condensed to a single `./scripts/setup-dev.sh` call instead of manual platform-specific steps

## Test report

The following agentic functions were tested in the browser on Ubuntu 24.04 with ROCm 7.2 (AMD Ryzen iGPU gfx1151, 48 GB VRAM):

- "Tell me about my system" — system info retrieved successfully
- "Scan for leaked secrets" — security scan completed
- "Find personal data" — PII detection completed
- "Summarize PDF on desktop" — a concise summary was generated in .pdf, .txt and .docx formats

Made with [Cursor](https://cursor.com)