### PR TITLE
feat(readme): add contributors section with contrib.rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Join the next session! Head to the `#live-events` channel on [Discord](https://d
 
 We welcome contributions! Open a PR with a link to your project GitHub repo in the Community Projects section.
 
+[![Contributors](https://contrib.rocks/image?repo=Liquid4All/cookbook)](https://github.com/Liquid4All/cookbook/graphs/contributors)
+
 ## Support
 
 - 📖 [Liquid AI Documentation](https://docs.liquid.ai/)


### PR DESCRIPTION
## Summary

- Adds a contributors image to the Contributing section using [contrib.rocks](https://contrib.rocks)
- Auto-updates from the repo's contributor graph, showing profile pictures linked to the GitHub contributors page
- Zero maintenance required

## Test plan

- [x] Verify the image renders correctly on the GitHub README
- [x] Confirm contributor avatars and links are accurate