### PR TITLE
docs: add BookMind to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Open-source projects built by the community showcasing LFMs with real use cases.
 | Meeting Intelligence CLI | CLI tool for meeting transcription and analysis | [Code](https://github.com/chintan-projects/meeting-prompter) |
 | grosme | CLI grocery assistant that finds Walmart product matches using an LFM-2.5 tool-calling agent via Ollama | [Code](https://github.com/earl562/grosme) |
 | Discord Moderator | Use LFM2.5-1.2B to screen messages for suspicious content | [Code](https://github.com/badluma/liquid-mod) |
+| BookMind | Offline RAG study assistant for asking questions and generating exercises from PDF textbooks, powered by LFM2-2.6B | [Code](https://github.com/Ksirailway-base/BookMind) |
 
 ## 🕐 Technical Deep Dives
 


### PR DESCRIPTION
## Summary

- Adds BookMind to the End-to-End Projects section of Community Projects
- Rebases onto current `main` (resolves conflict with the restructured community projects sections)
- Fixes entry name (removed subtitle) and description (single sentence, consistent style)

Closes #86

## Changes from original PR

- Moved entry to the correct **End-to-End Projects** subsection
- Renamed from `BookMind - Local AI teacher` to `BookMind`
- Rewrote description to match table style: `Offline RAG study assistant for asking questions and generating exercises from PDF textbooks, powered by LFM2-2.6B`