### PR TITLE
[codex] Add methane plume extraction demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Colab notebooks and Python scripts for customizing LFM models with your own data
 | **Vision-Language Models** | | |
 | VLM SFT with Unsloth | Supervised fine-tuning for LFM2-VL models on custom image-text datasets | [Notebook](./finetuning/notebooks/sft_for_vision_language_model.ipynb) |
 | Satellite VLM Fine-Tuning | Fine-tune LFM2.5-VL-450M on satellite imagery for VQA, grounding, and captioning using Modal | [Code](./examples/satellite-vlm/README.md) |
+| Methane Plume Extraction | Fine-tune LFM2.5-VL-1.6B to turn O&G methane observation images plus a fixed schema into auditable JSON records | [Code](./examples/methane-plume-extraction/README.md) |
 | Wildfire Prevention | Build a wildfire risk detection system using LFM2.5-VL-450M and Sentinel-2 satellite imagery, with fine-tuning and on-device inference | [Code](./examples/wildfire-prevention/README.md) |
 
 ## Third-Party Apps Powered by LFM

--- a/examples/methane-plume-extraction/.env.example
+++ b/examples/methane-plume-extraction/.env.example
@@ -1,0 +1,3 @@
+BASE_MODEL_ID=LiquidAI/LFM2.5-VL-1.6B
+FINE_MODEL_ID=felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo
+METHANE_INFER_URL=http://127.0.0.1:8791/infer

--- a/examples/methane-plume-extraction/.gitignore
+++ b/examples/methane-plume-extraction/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+.env
+.venv/
+venv/
+__pycache__/
+*.pyc
+models/
+*.safetensors
+*.bin
+*.gguf
+*.mlx
+*.log

--- a/examples/methane-plume-extraction/AGENTS.md
+++ b/examples/methane-plume-extraction/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md - Methane Plume Demo Runner
+
+## Mission
+
+Open and validate the local methane plume structured-output demo. Do not train,
+relabel, or regenerate the evaluation set from this repo. The expected behavior
+is:
+
+```text
+one rendered methane observation image + fixed schema -> one flat JSON object
+```
+
+## Operating Rules
+
+- Run commands from `examples/methane-plume-extraction/`.
+- Do not commit model weights, caches, `.env`, tokens, or generated `models/`
+  directories.
+- Keep the fine-tuned model private on Hugging Face unless the owner explicitly
+  changes that policy.
+- Use live inference for demos. Built-in samples include ground truth for
+  assessment, but model outputs should come from the local inference server.
+- The schema is intentionally fixed for the demo. Do not edit `schema.yaml`
+  during a customer demo. Treat key renames, new fields, changed allowed values,
+  or nested JSON as a new schema that needs re-evaluation before use.
+
+## Required Access
+
+The operator needs:
+
+- Read access to `LiquidAI/LFM2.5-VL-1.6B`.
+- Read access to the private fine-tuned model repo:
+
+```text
+felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo
+```
+
+Authenticate with:
+
+```bash
+hf auth login
+hf auth whoami
+```
+
+Prefer `HF_TOKEN` or `hf auth login`; do not paste tokens into scripts.
+
+## First-Time Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Download models:
+
+```bash
+./scripts/download_models.sh
+```
+
+This creates:
+
+```text
+models/base
+models/fine
+```
+
+## Run The Demo
+
+Terminal 1:
+
+```bash
+source .venv/bin/activate
+python scripts/serve_local_methane.py --preload fine
+```
+
+Terminal 2:
+
+```bash
+source .venv/bin/activate
+METHANE_INFER_URL=http://127.0.0.1:8791/infer \
+  python scripts/serve_demo.py
+```
+
+Open:
+
+```text
+http://127.0.0.1:8787/demo
+```
+
+## Smoke Test
+
+1. Select `Core absent`.
+2. Keep `Fine-tuned` selected.
+3. Click `Run`.
+4. Confirm the output tab shows valid JSON and latency.
+5. Confirm the assessment panel shows most fields verified.
+6. Switch to `Base`, click `Run`, and confirm the base model is visibly worse
+   at following the methane schema.
+
+The exact free-text evidence sentence may differ. Treat it as correct when the
+intent matches the ground truth and it does not add wrong visual information.
+
+## Expected Architecture
+
+```text
+browser -> scripts/serve_demo.py:/api/infer -> scripts/serve_local_methane.py:/infer -> local HF model
+```
+
+The visible endpoint control is hidden under the page's Advanced section because
+normal demo users should only choose a model and click Run.
+
+## If Something Fails
+
+- `401` or `403` during download: request Hugging Face access to the private
+  fine-tuned repo or use a token with the right account.
+- Browser output says endpoint unavailable: restart both servers and check
+  `METHANE_INFER_URL`.
+- Fine-tuned model emits captions instead of JSON: verify the fine model was
+  downloaded into `models/fine`, not accidentally pointed at the base model.
+- MLX output differs from Transformers: use the default Transformers backend for
+  the customer demo and investigate MLX parity separately.
+
+## Deployment Boundary
+
+This package is a demo runner. Production customer work should go back through
+the structured-output fine-tune process: customer schema, held-out eval set, L0
+baseline, fine-tune only if needed, LLM and VLM judge, then export/deploy.

--- a/examples/methane-plume-extraction/MODEL_ACCESS.md
+++ b/examples/methane-plume-extraction/MODEL_ACCESS.md
@@ -1,0 +1,59 @@
+# Model Access
+
+The demo does not store model weights in GitHub. Operators download the base and
+fine-tuned models from Hugging Face.
+
+## Base Model
+
+```text
+LiquidAI/LFM2.5-VL-1.6B
+```
+
+If Hugging Face requires acceptance of model terms, accept them from the model
+page before running `scripts/download_models.sh`.
+
+## Fine-Tuned Model
+
+The fine-tuned model should be a private Hugging Face model repo named:
+
+```text
+LFM2.5-1.6B-VL-Extract-Plume-Demo
+```
+
+Full repo id:
+
+```text
+felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo
+```
+
+Grant demo users read access to that private repo, then have them authenticate:
+
+```bash
+hf auth login
+hf auth whoami
+```
+
+They can then set:
+
+```bash
+export FINE_MODEL_ID=felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo
+```
+
+## Upload Reminder For The Owner
+
+If the private fine-tuned repo has not been uploaded yet:
+
+```bash
+hf repos create felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo \
+  --type model \
+  --private \
+  --exist-ok
+
+hf upload-large-folder \
+  felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo \
+  /path/to/LFM2.5-1.6B-VL-Extract-Plume-Demo \
+  --type model \
+  --private
+```
+
+Use `HF_TOKEN` or `hf auth login`; do not hard-code tokens.

--- a/examples/methane-plume-extraction/README.md
+++ b/examples/methane-plume-extraction/README.md
@@ -1,0 +1,234 @@
+# LFM-VL Methane Plume Extraction Demo
+
+This cookbook example packages a local demo for methane plume triage in oil and
+gas operations. It shows the structured-output workflow:
+
+```text
+rendered methane observation image + fixed customer schema -> JSON record
+```
+
+The demo compares the released base model against a methane-specialized fine-tune.
+The fine-tuned model was adapted with LEAP fine-tune so the model follows the
+schema used by this demo and returns one flat JSON object that an LDAR,
+emissions-monitoring, or operations workflow can route downstream.
+
+## Why This Demo Exists
+
+Methane monitoring today often produces images, not decisions. Airborne,
+satellite, drone, and site imagery still require reviewers to inspect each
+observation, filter false alarms such as steam or surface artifacts, and decide
+which events deserve repair-team follow-up.
+
+Traditional detection or segmentation models can highlight pixels that look like
+a plume. This demo shows the VLM layer on top: plume status, confidence,
+lookalike risk, timestamp/source context, evidence summary, alignment, and
+review priority in a customer-shaped JSON schema.
+
+## What Is Included
+
+- A browser demo with curated sample observations and ground-truth assessment.
+- A local inference server for the base and fine-tuned models.
+- The fixed methane schema used for prompting, evaluation, and demo output.
+- A model download helper for Hugging Face-hosted checkpoints.
+- `AGENTS.md` and `agent.md` runbooks for another agent or teammate opening the demo.
+
+This example intentionally does not include model weights. The base model and
+fine-tuned private model are downloaded from Hugging Face.
+
+## Model Access
+
+The base model is:
+
+```text
+LiquidAI/LFM2.5-VL-1.6B
+```
+
+The fine-tuned model should be hosted as this private Hugging Face model repo:
+
+```text
+felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo
+```
+
+Anyone running the demo needs a Hugging Face token with read access to the
+private fine-tuned model. See [MODEL_ACCESS.md](MODEL_ACCESS.md).
+
+## Prompt Shape And Schema
+
+This fine-tuned demo should be run with the same schema-conditioned prompt shape
+used during training and evaluation:
+
+```text
+Extract the following from the image:
+
+<schema.yaml contents>
+```
+
+The model is expected to return exactly one flat JSON object with the schema
+keys below. For this demo, treat the schema as fixed: small wording edits to
+field descriptions may still work, but changing key names, adding/removing
+fields, changing allowed values, or moving to nested JSON should be treated as a
+new schema and re-evaluated before showing it to a customer.
+
+Exact schema:
+
+```yaml
+methane_plume_status: Exact methane plume assessment from the rendered image using one of present, absent, or uncertain.
+plume_confidence: Confidence in the plume assessment using one of low, medium, or high.
+plume_extent: Approximate visible plume extent in the methane product using one of none, small, medium, or large.
+plume_location: Approximate visible plume location in the image using one of top_left, top_right, center, bottom_left, bottom_right, or unknown.
+lookalike_risk: Most likely non-methane visual explanation using one of steam, dust, cloud_shadow, surface_artifact, sensor_artifact, albedo_confuser, none, or unknown.
+visual_evidence_summary: One short image-only sentence describing the visible evidence without source metadata or operational recommendations.
+observation_timestamp_utc: Observation timestamp shown in the observation context panel as ISO-8601 UTC, or unknown when unavailable.
+source_context: Supplied source type shown in the observation context panel using one of well_pad, compressor_station, pipeline_corridor, processing_facility, landfill, mine, agriculture, unknown, or not_applicable.
+source_alignment_assessment: Whether visible plume evidence aligns with supplied source context using one of aligned, source_context_unavailable, no_visible_plume, or unknown.
+review_priority: Human review priority for the observation using one of low, medium, or high.
+```
+
+## Quickstart
+
+Run from `examples/methane-plume-extraction/`.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Install the Hugging Face CLI if needed:
+
+```bash
+curl -LsSf https://hf.co/cli/install.sh | bash -s
+hf auth login
+hf auth whoami
+```
+
+Download both models:
+
+```bash
+./scripts/download_models.sh
+```
+
+If the private model is hosted under a different namespace, override it with
+`FINE_MODEL_ID`.
+
+Start local inference. On Apple Silicon, the default `transformers` backend uses
+MPS automatically.
+
+```bash
+python scripts/serve_local_methane.py --preload fine
+```
+
+In a second terminal:
+
+```bash
+source .venv/bin/activate
+METHANE_INFER_URL=http://127.0.0.1:8791/infer \
+  python scripts/serve_demo.py
+```
+
+Open:
+
+```text
+http://127.0.0.1:8787/demo
+```
+
+Select a sample image, choose Base or Fine-tuned, then click Run. The output is
+generated live by the local model server.
+
+## Demo Flow
+
+1. The page loads curated rendered methane observations.
+2. The page sends the selected image and the fixed schema to `/api/infer`.
+3. `scripts/serve_demo.py` proxies the request to the local inference server.
+4. `scripts/serve_local_methane.py` runs the selected model and returns:
+
+```json
+{
+  "prediction_json": {
+    "methane_plume_status": "present",
+    "plume_confidence": "high",
+    "plume_extent": "medium",
+    "plume_location": "center",
+    "lookalike_risk": "none",
+    "visual_evidence_summary": "Coherent plume-like enhancement is visible in the methane product panel.",
+    "observation_timestamp_utc": "2019-10-21T18:19:27Z",
+    "source_context": "well_pad",
+    "source_alignment_assessment": "aligned",
+    "review_priority": "high"
+  },
+  "latency_ms": 2561
+}
+```
+
+The demo page then compares the JSON against held-out ground truth for built-in
+samples. Uploaded customer images run through the same schema, but they do not
+have ground truth unless you add it.
+
+## Fine-Tune Context
+
+The demo fine-tune used public methane imagery and replay data:
+
+- STARCOP / AVIRIS-NG style rendered methane plume products.
+- MethaneSET-style Sentinel-2, Landsat 8/9, and EMIT observations.
+- JPL AVIRIS-NG methane benchmark style examples.
+- Replay rows to reduce regression against the base structured-output behavior.
+
+Latest demo training package:
+
+```text
+20,650 rows total
+17,234 methane/context rows
+3,416 replay rows
+1h 28m 47s training on 1x NVIDIA H100 after data upload
+~$5.84 training cost + $0 upload cost for the latest run
+```
+
+This is a controlled demo artifact, not a production methane-compliance system.
+Production deployment should use customer-owned imagery, customer-approved
+labels, held-out evals, and the customer schema.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `interactive_v6_demo.html` | Self-contained browser UI with embedded sample images and ground truth. |
+| `schema.yaml` | Fixed flat schema sent to the model. |
+| `scripts/serve_demo.py` | Static web server plus `/api/infer` proxy. |
+| `scripts/serve_local_methane.py` | Local base/fine model inference server. |
+| `scripts/download_models.sh` | Downloads base and fine-tuned models from Hugging Face. |
+| `AGENTS.md` | Canonical agent runbook for opening and validating the demo. |
+| `agent.md` | Short human-facing local-demo shortcut. |
+
+## Backend Notes
+
+The default path uses Hugging Face Transformers because it matched the evaluated
+fine-tuned checkpoint during local testing. MLX can be tried with
+`--backend mlx`, but validate output parity before using MLX in a customer
+meeting.
+
+Model directories expected by default:
+
+```text
+models/base
+models/fine
+```
+
+You can override them:
+
+```bash
+python scripts/serve_local_methane.py \
+  --base-model /path/to/base \
+  --fine-model /path/to/fine \
+  --preload fine
+```
+
+## Troubleshooting
+
+- If downloads fail with `401` or `403`, the token does not have access to the
+  private fine-tuned model.
+- If `AutoModelForImageTextToText` is missing, upgrade `transformers`.
+- If the browser says the endpoint is unavailable, confirm both servers are
+  running and that `METHANE_INFER_URL` points to `http://127.0.0.1:8791/infer`.
+- CPU inference works but is slow. Apple Silicon MPS is the recommended local
+  path for this package.

--- a/examples/methane-plume-extraction/README.md
+++ b/examples/methane-plume-extraction/README.md
@@ -30,6 +30,8 @@ review priority in a customer-shaped JSON schema.
 - A local inference server for the base and fine-tuned models.
 - The fixed methane schema used for prompting, evaluation, and demo output.
 - A model download helper for Hugging Face-hosted checkpoints.
+- A [training recipe](training/README.md) with the exact schema, LEAP config,
+  dataset manifest, and sample row format used for the demo checkpoint.
 - `AGENTS.md` and `agent.md` runbooks for another agent or teammate opening the demo.
 
 This example intentionally does not include model weights. The base model and

--- a/examples/methane-plume-extraction/README.md
+++ b/examples/methane-plume-extraction/README.md
@@ -194,9 +194,9 @@ labels, held-out evals, and the customer schema.
 
 | Path | Purpose |
 |---|---|
-| `interactive_v6_demo.html` | Self-contained browser UI with embedded sample images and ground truth. |
+| `interactive_demo.html` | Self-contained browser UI with embedded sample images and ground truth. |
 | `schema.yaml` | Fixed flat schema sent to the model. |
-| `scripts/serve_demo.py` | Static web server plus `/api/infer` proxy. |
+| `scripts/serve_demo.py` | Static web server plus `/api/infer` endpoint bridge. |
 | `scripts/serve_local_methane.py` | Local base/fine model inference server. |
 | `scripts/download_models.sh` | Downloads base and fine-tuned models from Hugging Face. |
 | `AGENTS.md` | Canonical agent runbook for opening and validating the demo. |

--- a/examples/methane-plume-extraction/README.md
+++ b/examples/methane-plume-extraction/README.md
@@ -173,17 +173,20 @@ The demo fine-tune used public methane imagery and replay data:
 
 - STARCOP / AVIRIS-NG style rendered methane plume products.
 - MethaneSET-style Sentinel-2, Landsat 8/9, and EMIT observations.
-- JPL AVIRIS-NG methane benchmark style examples.
 - Replay rows to reduce regression against the base structured-output behavior.
 
-Latest demo training package:
+JPL AVIRIS-NG benchmark scenes were used for source/eval exploration and
+held-out demo evaluation, but they are not counted as final training rows in
+the manifest.
+
+Demo training package:
 
 ```text
 20,650 rows total
 17,234 methane/context rows
 3,416 replay rows
 1h 28m 47s training on 1x NVIDIA H100 after data upload
-~$5.84 training cost + $0 upload cost for the latest run
+~$5.84 estimated training cost + $0 upload cost for this run
 ```
 
 This is a controlled demo artifact, not a production methane-compliance system.

--- a/examples/methane-plume-extraction/agent.md
+++ b/examples/methane-plume-extraction/agent.md
@@ -1,0 +1,45 @@
+# agent.md - Open The Demo Locally
+
+This is the human-facing shortcut. The canonical agent runbook is
+[AGENTS.md](AGENTS.md).
+
+## Quick Path
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+hf auth login
+./scripts/download_models.sh
+```
+
+Terminal 1:
+
+```bash
+source .venv/bin/activate
+python scripts/serve_local_methane.py --preload fine
+```
+
+Terminal 2:
+
+```bash
+source .venv/bin/activate
+METHANE_INFER_URL=http://127.0.0.1:8791/infer python scripts/serve_demo.py
+```
+
+Open:
+
+```text
+http://127.0.0.1:8787/demo
+```
+
+Select an image, choose Base or Fine-tuned, then click Run.
+
+## What Should Happen
+
+The browser sends one rendered methane observation plus the fixed schema to the
+local model server. The selected model returns one flat JSON object. Built-in
+samples show an assessment against ground truth; uploaded images show live JSON
+without ground-truth scoring.

--- a/examples/methane-plume-extraction/requirements.txt
+++ b/examples/methane-plume-extraction/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.115
 uvicorn[standard]>=0.30
 pillow>=10.0
 pydantic>=2.8
+pyyaml>=6.0
 torch>=2.4
 torchvision>=0.19
 transformers>=5.0.0

--- a/examples/methane-plume-extraction/requirements.txt
+++ b/examples/methane-plume-extraction/requirements.txt
@@ -1,0 +1,11 @@
+fastapi>=0.115
+uvicorn[standard]>=0.30
+pillow>=10.0
+pydantic>=2.8
+torch>=2.4
+torchvision>=0.19
+transformers>=5.0.0
+accelerate>=1.0
+huggingface_hub>=0.33
+hf_xet>=1.1
+mlx-vlm>=0.5.0; platform_system == "Darwin" and platform_machine == "arm64"

--- a/examples/methane-plume-extraction/schema.yaml
+++ b/examples/methane-plume-extraction/schema.yaml
@@ -1,0 +1,10 @@
+methane_plume_status: Exact methane plume assessment from the rendered image using one of present, absent, or uncertain.
+plume_confidence: Confidence in the plume assessment using one of low, medium, or high.
+plume_extent: Approximate visible plume extent in the methane product using one of none, small, medium, or large.
+plume_location: Approximate visible plume location in the image using one of top_left, top_right, center, bottom_left, bottom_right, or unknown.
+lookalike_risk: Most likely non-methane visual explanation using one of steam, dust, cloud_shadow, surface_artifact, sensor_artifact, albedo_confuser, none, or unknown.
+visual_evidence_summary: One short image-only sentence describing the visible evidence without source metadata or operational recommendations.
+observation_timestamp_utc: Observation timestamp shown in the observation context panel as ISO-8601 UTC, or unknown when unavailable.
+source_context: Supplied source type shown in the observation context panel using one of well_pad, compressor_station, pipeline_corridor, processing_facility, landfill, mine, agriculture, unknown, or not_applicable.
+source_alignment_assessment: Whether visible plume evidence aligns with supplied source context using one of aligned, source_context_unavailable, no_visible_plume, or unknown.
+review_priority: Human review priority for the observation using one of low, medium, or high.

--- a/examples/methane-plume-extraction/scripts/download_models.sh
+++ b/examples/methane-plume-extraction/scripts/download_models.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_MODEL_ID="${BASE_MODEL_ID:-LiquidAI/LFM2.5-VL-1.6B}"
+FINE_MODEL_ID="${FINE_MODEL_ID:-felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo}"
+BASE_DIR="${BASE_DIR:-models/base}"
+FINE_DIR="${FINE_DIR:-models/fine}"
+
+if ! command -v hf >/dev/null 2>&1; then
+  echo "Missing Hugging Face CLI. Install with:"
+  echo "  curl -LsSf https://hf.co/cli/install.sh | bash -s"
+  exit 1
+fi
+
+if [[ -z "${FINE_MODEL_ID}" ]]; then
+  echo "Set FINE_MODEL_ID to the private fine-tuned model repo id."
+  echo "Example:"
+  echo "  export FINE_MODEL_ID=felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo"
+  exit 2
+fi
+
+if ! hf auth whoami >/dev/null 2>&1; then
+  echo "You are not logged into Hugging Face. Run:"
+  echo "  hf auth login"
+  exit 3
+fi
+
+mkdir -p "${BASE_DIR}" "${FINE_DIR}"
+
+echo "Downloading base model: ${BASE_MODEL_ID} -> ${BASE_DIR}"
+hf download "${BASE_MODEL_ID}" --local-dir "${BASE_DIR}"
+
+echo "Downloading fine-tuned model: ${FINE_MODEL_ID} -> ${FINE_DIR}"
+hf download "${FINE_MODEL_ID}" --local-dir "${FINE_DIR}"
+
+echo "Done."

--- a/examples/methane-plume-extraction/scripts/serve_demo.py
+++ b/examples/methane-plume-extraction/scripts/serve_demo.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Serve the interactive v6 demo and optional inference proxy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DemoHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(ROOT), **kwargs)
+
+    def do_GET(self):  # noqa: N802
+        if self.path in {"/", "/demo"}:
+            self.path = "/interactive_v6_demo.html"
+        return super().do_GET()
+
+    def do_POST(self):  # noqa: N802
+        if self.path != "/api/infer":
+            self.send_error(404, "Not found")
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        target = self._infer_target(body)
+        if not target:
+            self._send_json(
+                503,
+                {
+                    "error": "No inference endpoint is configured for this model variant.",
+                    "expected": "Set METHANE_INFER_FINE_URL and/or METHANE_INFER_BASE_URL, or set METHANE_INFER_URL as a fallback endpoint.",
+                },
+            )
+            return
+
+        request = Request(
+            target,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=180) as response:
+                payload = response.read()
+                status = response.status
+                content_type = response.headers.get("Content-Type", "application/json")
+        except HTTPError as exc:
+            payload = exc.read() or json.dumps({"error": str(exc)}).encode("utf-8")
+            status = exc.code
+            content_type = exc.headers.get("Content-Type", "application/json")
+        except URLError as exc:
+            self._send_json(502, {"error": f"Inference endpoint unavailable: {exc.reason}"})
+            return
+        except TimeoutError:
+            self._send_json(504, {"error": "Inference endpoint timed out."})
+            return
+
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_OPTIONS(self):  # noqa: N802
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.end_headers()
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        raw = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _infer_target(self, body: bytes) -> str:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = {}
+
+        variant = str(payload.get("model_variant", "fine")).strip().lower()
+        if variant == "base":
+            return os.environ.get("METHANE_INFER_BASE_URL", "").strip() or os.environ.get("METHANE_INFER_URL", "").strip()
+        return os.environ.get("METHANE_INFER_FINE_URL", "").strip() or os.environ.get("METHANE_INFER_URL", "").strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Serve the methane plume interactive demo")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), DemoHandler)
+    print(f"Serving methane plume demo at http://{args.host}:{args.port}/demo")
+    if os.environ.get("METHANE_INFER_URL"):
+        print(f"Proxying /api/infer to {os.environ['METHANE_INFER_URL']}")
+    if os.environ.get("METHANE_INFER_BASE_URL"):
+        print(f"Proxying base-model uploads to {os.environ['METHANE_INFER_BASE_URL']}")
+    if os.environ.get("METHANE_INFER_FINE_URL"):
+        print(f"Proxying fine-tuned uploads to {os.environ['METHANE_INFER_FINE_URL']}")
+    else:
+        print("METHANE_INFER_FINE_URL not set; fine-tuned uploads will use METHANE_INFER_URL or report not configured.")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/methane-plume-extraction/scripts/serve_demo.py
+++ b/examples/methane-plume-extraction/scripts/serve_demo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Serve the interactive v6 demo and optional inference proxy."""
+"""Serve the interactive methane plume demo and optional inference endpoint bridge."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ class DemoHandler(SimpleHTTPRequestHandler):
 
     def do_GET(self):  # noqa: N802
         if self.path in {"/", "/demo"}:
-            self.path = "/interactive_v6_demo.html"
+            self.path = "/interactive_demo.html"
         return super().do_GET()
 
     def do_POST(self):  # noqa: N802

--- a/examples/methane-plume-extraction/scripts/serve_local_methane.py
+++ b/examples/methane-plume-extraction/scripts/serve_local_methane.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Serve local inference for the methane plume demo.
+
+The default backend is Transformers because it matches the evaluated HF
+checkpoint. On Apple Silicon it uses MPS automatically. The MLX backend is kept
+available for Liquid-docs-style Apple Silicon testing, but validate parity before
+using it for a customer demo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import importlib
+import json
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from PIL import Image
+from pydantic import BaseModel, ConfigDict, Field
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FINE_MODEL = os.environ.get(
+    "FINE_MODEL_ID",
+    str(ROOT / "models" / "fine"),
+)
+DEFAULT_BASE_MODEL = os.environ.get(
+    "BASE_MODEL_ID",
+    str(ROOT / "models" / "base"),
+)
+DEFAULT_FINE_MLX_MODEL = os.environ.get("FINE_MLX_MODEL_ID", str(ROOT / "models" / "fine-mlx"))
+DEFAULT_BASE_MLX_MODEL = os.environ.get("BASE_MLX_MODEL_ID", "mlx-community/LFM2.5-VL-1.6B-4bit")
+JSON_FOOTER = "\n\nRespond with only a JSON object. Do not include any text outside the JSON."
+
+
+def patch_mlx_detokenizer() -> None:
+    """Work around an mlx-vlm 0.5.0 copy() issue on the LFM2-VL detokenizer."""
+
+    import mlx_vlm.tokenizer_utils as tokenizer_utils
+
+    def no_copy_detokenizer(processor):
+        detok = processor.detokenizer
+        detok.reset()
+        return detok
+
+    generate_module = importlib.import_module("mlx_vlm.generate")
+    tokenizer_utils.make_streaming_detokenizer = no_copy_detokenizer
+    generate_module.make_streaming_detokenizer = no_copy_detokenizer
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    clean = (text or "").strip()
+    if clean.startswith("```"):
+        clean = clean.split("\n", 1)[1] if "\n" in clean else clean[3:]
+        clean = clean.rsplit("```", 1)[0].strip()
+    start = clean.find("{")
+    if start < 0:
+        return {}
+    depth = 0
+    in_string = False
+    escape = False
+    for i, ch in enumerate(clean[start:], start):
+        if escape:
+            escape = False
+            continue
+        if ch == "\\" and in_string:
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    parsed = json.loads(clean[start : i + 1])
+                    return parsed if isinstance(parsed, dict) else {}
+                except json.JSONDecodeError:
+                    return {}
+    return {}
+
+
+def schema_to_yaml(schema: dict[str, Any]) -> str:
+    lines = []
+    for key, value in schema.items():
+        lines.append(f"{key}: {value}")
+    return "\n".join(lines)
+
+
+def prompt_from_request(prompt: str | None, schema: dict[str, Any] | None) -> str:
+    if prompt:
+        system = prompt.strip()
+    elif schema:
+        system = "Extract the following from the image:\n\n" + schema_to_yaml(schema)
+    else:
+        raise HTTPException(status_code=400, detail="Request must include prompt or schema.")
+    if "Respond with only a JSON object" not in system:
+        system += JSON_FOOTER
+    return system
+
+
+def decode_image_bytes(image_b64: str) -> tuple[bytes, str]:
+    if not image_b64:
+        raise HTTPException(status_code=400, detail="Missing image_b64.")
+    suffix = ".png"
+    payload = image_b64
+    if "," in image_b64 and image_b64.startswith("data:"):
+        header, payload = image_b64.split(",", 1)
+        if "jpeg" in header or "jpg" in header:
+            suffix = ".jpg"
+    try:
+        raw = base64.b64decode(payload)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=f"Invalid base64 image: {exc}") from exc
+    return raw, suffix
+
+
+def decode_image_to_tempfile(image_b64: str) -> tempfile.NamedTemporaryFile:
+    raw, suffix = decode_image_bytes(image_b64)
+    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    tmp.write(raw)
+    tmp.flush()
+    tmp.close()
+    return tmp
+
+
+class InferRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    image_b64: str
+    schema_payload: dict[str, Any] | None = Field(default=None, alias="schema")
+    prompt: str | None = None
+    model_variant: str = "fine"
+    filename: str | None = None
+
+
+class ModelCache:
+    def __init__(
+        self,
+        fine_model: str,
+        base_model: str,
+        backend: Literal["transformers", "mlx"],
+        preload: str,
+        device: str,
+    ) -> None:
+        self.paths = {"fine": fine_model, "base": base_model}
+        self.models: dict[str, tuple[Any, Any]] = {}
+        self.lock = threading.Lock()
+        self.backend = backend
+        self.device = device
+        if self.backend == "mlx":
+            patch_mlx_detokenizer()
+        if preload in {"fine", "both"}:
+            self.get("fine")
+        if preload == "both":
+            self.get("base")
+
+    def get(self, variant: str):
+        key = "base" if variant == "base" else "fine"
+        if key not in self.models:
+            self.models[key] = self._load_model(self.paths[key])
+        return self.models[key]
+
+    def _load_model(self, path: str) -> tuple[Any, Any]:
+        if self.backend == "mlx":
+            from mlx_vlm import load
+
+            return load(path)
+
+        import torch
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
+        device = self.device
+        if device == "auto":
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
+        if device == "cuda":
+            dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+        elif device == "mps":
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+        processor = AutoProcessor.from_pretrained(path, trust_remote_code=True)
+        model = AutoModelForImageTextToText.from_pretrained(
+            path,
+            trust_remote_code=True,
+            dtype=dtype,
+        )
+        model = model.to(device)
+        model.eval()
+        return model, processor
+
+    def infer(self, request: InferRequest, max_tokens: int) -> dict[str, Any]:
+        model, processor = self.get(request.model_variant)
+        system = prompt_from_request(request.prompt, request.schema_payload)
+        if self.backend == "mlx":
+            return self._infer_mlx(model, processor, request, system, max_tokens)
+        return self._infer_transformers(model, processor, request, system, max_tokens)
+
+    def _infer_mlx(
+        self,
+        model: Any,
+        processor: Any,
+        request: InferRequest,
+        system: str,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        from mlx_vlm import generate
+        from mlx_vlm.prompt_utils import apply_chat_template
+
+        image_file = decode_image_to_tempfile(request.image_b64)
+        started = time.perf_counter()
+        try:
+            messages = [
+                {"role": "system", "content": system},
+                {"role": "user", "content": ""},
+            ]
+            prompt = apply_chat_template(processor, model.config, messages, num_images=1)
+            with self.lock:
+                result = generate(
+                    model,
+                    processor,
+                    prompt,
+                    image=[image_file.name],
+                    max_tokens=max_tokens,
+                    temperature=0.0,
+                    prefill_step_size=512,
+                    verbose=False,
+                )
+            raw = result.text.strip()
+            prediction = extract_json(raw)
+            return {
+                "prediction_json": prediction,
+                "prediction_raw": raw,
+                "model_variant": "base" if request.model_variant == "base" else "fine",
+                "engine": "mlx-vlm",
+                "latency_ms": round((time.perf_counter() - started) * 1000),
+            }
+        finally:
+            Path(image_file.name).unlink(missing_ok=True)
+
+    def _infer_transformers(
+        self,
+        model: Any,
+        processor: Any,
+        request: InferRequest,
+        system: str,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        import torch
+
+        raw_bytes, _ = decode_image_bytes(request.image_b64)
+        image = Image.open(io.BytesIO(raw_bytes)).convert("RGB")
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": system}]},
+            {"role": "user", "content": [{"type": "image", "image": image}]},
+        ]
+        started = time.perf_counter()
+        with self.lock:
+            text = processor.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+            inputs = processor(text=text, images=[image], return_tensors="pt")
+            device = next(model.parameters()).device
+            inputs = {k: v.to(device) if hasattr(v, "to") else v for k, v in inputs.items()}
+            with torch.no_grad():
+                output_ids = model.generate(
+                    **inputs,
+                    max_new_tokens=max_tokens,
+                    do_sample=False,
+                )
+            input_len = inputs["input_ids"].shape[-1]
+            generated_ids = output_ids[:, input_len:]
+            raw = processor.batch_decode(generated_ids, skip_special_tokens=True)[0].strip()
+        prediction = extract_json(raw)
+        return {
+            "prediction_json": prediction,
+            "prediction_raw": raw,
+            "model_variant": "base" if request.model_variant == "base" else "fine",
+            "engine": f"transformers-{next(model.parameters()).device}",
+            "latency_ms": round((time.perf_counter() - started) * 1000),
+        }
+
+
+def create_app(cache: ModelCache, max_tokens: int) -> FastAPI:
+    app = FastAPI(title="Methane plume local inference")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "loaded": sorted(cache.models.keys()),
+            "engine": cache.backend,
+            "device": cache.device,
+        }
+
+    @app.post("/infer")
+    def infer(request: InferRequest) -> dict[str, Any]:
+        return cache.infer(request, max_tokens=max_tokens)
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run local inference for the methane plume demo")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8791)
+    parser.add_argument("--fine-model", default=DEFAULT_FINE_MODEL)
+    parser.add_argument("--base-model", default=DEFAULT_BASE_MODEL)
+    parser.add_argument("--fine-mlx-model", default=DEFAULT_FINE_MLX_MODEL)
+    parser.add_argument("--base-mlx-model", default=DEFAULT_BASE_MLX_MODEL)
+    parser.add_argument("--backend", choices=["transformers", "mlx"], default="transformers")
+    parser.add_argument("--device", default="auto", help="transformers device: auto, cuda, mps, or cpu")
+    parser.add_argument("--preload", choices=["none", "fine", "both"], default="fine")
+    parser.add_argument("--max-tokens", type=int, default=512)
+    args = parser.parse_args()
+
+    fine_model = args.fine_mlx_model if args.backend == "mlx" else args.fine_model
+    base_model = args.base_mlx_model if args.backend == "mlx" else args.base_model
+    cache = ModelCache(fine_model, base_model, args.backend, args.preload, args.device)
+    app = create_app(cache, max_tokens=args.max_tokens)
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/methane-plume-extraction/training/README.md
+++ b/examples/methane-plume-extraction/training/README.md
@@ -1,0 +1,216 @@
+# Fine-Tuning Recipe
+
+This folder documents the training recipe used to produce the private demo
+checkpoint:
+
+```text
+felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo
+```
+
+The runtime demo is intentionally "give them the fish"; this folder is the
+"teach them to fish" part. It shows the schema, dataset shape, manifest, and
+LEAP fine-tuning config used for the demo checkpoint.
+
+## What Was Trained
+
+The task is schema-conditioned visual extraction:
+
+```text
+rendered methane observation image + fixed schema -> one flat JSON object
+```
+
+Base model:
+
+```text
+LiquidAI/LFM2.5-VL-1.6B
+```
+
+Final training mix:
+
+| Component | Rows |
+|---|---:|
+| Methane/context rows | 17,234 |
+| Structured-output replay rows | 3,416 |
+| Total | 20,650 |
+
+The methane rows used the fixed schema in [`schema.yaml`](schema.yaml). Replay
+rows came from other strict-JSON VLM extraction tasks and were mixed in to
+reduce regression on general structured-output behavior.
+
+## Public Data Sources
+
+The checkpoint was built from public methane remote-sensing sources rendered
+into demo-friendly observation images.
+
+| Source | How it was used | License / note |
+|---|---|---|
+| [STARCOP](https://zenodo.org/records/7863343) | Main absent/uncertain set and some present examples using AVIRIS-NG / simulated multispectral products | Zenodo lists CC-BY-NC-4.0. Do not redistribute derived imagery without checking usage. |
+| [MethaneSET](https://huggingface.co/datasets/tacofoundation/methaneset) | Present examples from Sentinel-2, Landsat 8/9, and EMIT-derived products | Hugging Face lists cc-by-nc-sa-4.0. Do not redistribute derived imagery without checking usage. |
+| [JPL AVIRIS-NG CH4/CO2 benchmark](https://avirisng.jpl.nasa.gov/benchmark_methane_carbon_dioxide.html) | Used in source/eval exploration and the held-out proxy eval; not counted as a final v6 training source in the training manifest | JPL page describes ten AVIRIS-NG scenes with methane and carbon dioxide point-source emissions. |
+
+The cookbook does **not** redistribute source imagery, rendered train images, or
+the 20,650-row training JSONL. Users should regenerate their own dataset from
+source data they are allowed to use, or use their own customer imagery.
+
+## Exact Dataset Manifest
+
+[`training_manifest_context_v6.json`](training_manifest_context_v6.json)
+records the exact final training mix, checksums, hyperparameters, and eval
+scores. The key values are:
+
+```text
+train.jsonl SHA-256: b95c62e532769f8070fd1dcaa94e5207e8392389194f8f7add63ec36fc84e904
+methane labels SHA-256: 97a439af58bf985a23fa6505fcae2237affd44af02030232d2a71b446b4eb3fa
+schema SHA-256: dd7ddbdf57b272e71e29c6a86af98156bf2f158f5a244880300fe0de43066cfe
+```
+
+Final methane row counts:
+
+| Field | Counts |
+|---|---|
+| `methane_plume_status` | absent 5,750; present 9,734; uncertain 1,750 |
+| `source_dataset` | STARCOP 10,904; MethaneSET 6,146; unknown/context-extra 184 |
+| `source_context` | not_applicable 5,750; unknown 3,430; well_pad 3,070; landfill 945; mine 839; agriculture 800; processing_facility 800; pipeline_corridor 800; compressor_station 800 |
+
+The `unknown/context-extra` bucket is preserved from the original manifest. Most
+of those rows were MethaneSET EMIT-derived context examples whose
+`source_dataset` field was not normalized in the local manifest.
+
+## Training Row Format
+
+LEAP VLM SFT consumed a JSONL file where each row contains a `sample_id` and
+`messages`. See [`sample_train_row.json`](sample_train_row.json).
+
+The important shape is:
+
+```json
+{
+  "sample_id": "methane:...",
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {
+          "type": "text",
+          "text": "Extract the following from the image:\n\n<schema.yaml contents>"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "image",
+          "image": "/outputs/.../image.png"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "{\"methane_plume_status\":\"absent\",...}"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The assistant text is a compact JSON string, not a nested object.
+
+## Preparing A Training Bundle
+
+If you already have labels in this local eval-style format:
+
+```json
+{
+  "image": "/absolute/path/to/rendered_observation.png",
+  "schema": {"methane_plume_status": "..."},
+  "ground_truth": {"methane_plume_status": "present"},
+  "metadata": {"sample_id": "source:id", "source_dataset": "starcop"}
+}
+```
+
+you can convert them into the LEAP VLM SFT message format with:
+
+```bash
+python training/scripts/prepare_modal_training_bundle_with_replay.py \
+  --schema training/schema.yaml \
+  --labels-jsonl /path/to/methane_train_context_v6_17234.jsonl \
+  --bundle-root /path/to/local_bundle_root \
+  --dataset-name methane_plume_context_v6_train17234_replay20650 \
+  --remote-root /outputs/methane_plume_context_v6_train17234_replay20650 \
+  --min-samples 10000 \
+  --replay real_iad:/path/to/real_iad_train.jsonl:1500 \
+  --replay visa:/path/to/visa_train.jsonl:1500 \
+  --replay forge:/path/to/forge_train.jsonl:416
+```
+
+This writes:
+
+```text
+/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/train.local.jsonl
+/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/train.jsonl
+/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/manifest.json
+/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/images/
+```
+
+`train.local.jsonl` points at local image paths. `train.jsonl` points at the
+Modal volume paths used by the LEAP config.
+
+## Fine-Tuning With LEAP
+
+The exact config used for the demo checkpoint is
+[`leap_finetune_modal.yaml`](leap_finetune_modal.yaml).
+
+After staging `train.jsonl` and its `images/` directory into the Modal volume so
+that this path exists:
+
+```text
+/outputs/methane_plume_context_v6_train17234_replay20650/train.jsonl
+```
+
+run LEAP fine-tune from a checkout with VLM SFT support:
+
+```bash
+leap-finetune examples/methane-plume-extraction/training/leap_finetune_modal.yaml
+```
+
+The demo run used:
+
+```text
+1x NVIDIA H100 on Modal
+1 epoch
+2,529 steps
+LoRA r=16, alpha=32
+learning rate 2e-5
+runtime 1h 28m 47s after data upload
+final train loss 0.04211
+final eval loss 0.01687
+```
+
+## Eval Summary
+
+The held-out evals are proxy demo labels, not customer-adjudicated production
+gold.
+
+| Split | Samples | JSON valid | Strict value exact | LLM judge | VLM judge |
+|---|---:|---:|---:|---:|---:|
+| Core | 235 | 100.0% | 94.4% | 0.959 | 0.889 |
+| Stress | 265 | 100.0% | 77.5% | 0.821 | 0.826 |
+
+Known limitation: the `uncertain` class remained weak on stress examples and
+was often over-called as `present`.
+
+## Reproducibility Notes
+
+- This folder documents the checkpoint recipe; it does not make the private
+  model or the source datasets public.
+- The final training labels were best-effort demo labels. For a customer or
+  production system, replace them with customer-approved human labels.
+- The rendered context panel is demo metadata. It should not be described as
+  independent GIS/source attribution.
+- Before sharing rendered images or derived labels, review the source licenses
+  and attribution requirements.

--- a/examples/methane-plume-extraction/training/README.md
+++ b/examples/methane-plume-extraction/training/README.md
@@ -46,7 +46,7 @@ into demo-friendly observation images.
 |---|---|---|
 | [STARCOP](https://zenodo.org/records/7863343) | Main absent/uncertain set and some present examples using AVIRIS-NG / simulated multispectral products | Zenodo lists CC-BY-NC-4.0. Do not redistribute derived imagery without checking usage. |
 | [MethaneSET](https://huggingface.co/datasets/tacofoundation/methaneset) | Present examples from Sentinel-2, Landsat 8/9, and EMIT-derived products | Hugging Face lists cc-by-nc-sa-4.0. Do not redistribute derived imagery without checking usage. |
-| [JPL AVIRIS-NG CH4/CO2 benchmark](https://avirisng.jpl.nasa.gov/benchmark_methane_carbon_dioxide.html) | Used in source/eval exploration and the held-out proxy eval; not counted as a final v6 training source in the training manifest | JPL page describes ten AVIRIS-NG scenes with methane and carbon dioxide point-source emissions. |
+| [JPL AVIRIS-NG CH4/CO2 benchmark](https://avirisng.jpl.nasa.gov/benchmark_methane_carbon_dioxide.html) | Used in source/eval exploration and held-out demo evaluation; not counted as a final training source in the manifest | JPL page describes ten AVIRIS-NG scenes with methane and carbon dioxide point-source emissions. |
 
 The cookbook does **not** redistribute source imagery, rendered train images, or
 the 20,650-row training JSONL. Users should regenerate their own dataset from
@@ -54,7 +54,7 @@ source data they are allowed to use, or use their own customer imagery.
 
 ## Exact Dataset Manifest
 
-[`training_manifest_context_v6.json`](training_manifest_context_v6.json)
+[`training_manifest.json`](training_manifest.json)
 records the exact final training mix, checksums, hyperparameters, and eval
 scores. The key values are:
 
@@ -138,10 +138,10 @@ you can convert them into the LEAP VLM SFT message format with:
 ```bash
 python training/scripts/prepare_modal_training_bundle_with_replay.py \
   --schema training/schema.yaml \
-  --labels-jsonl /path/to/methane_train_context_v6_17234.jsonl \
+  --labels-jsonl /path/to/methane_train_observation_17234.jsonl \
   --bundle-root /path/to/local_bundle_root \
-  --dataset-name methane_plume_context_v6_train17234_replay20650 \
-  --remote-root /outputs/methane_plume_context_v6_train17234_replay20650 \
+  --dataset-name methane_plume_observation_train17234_replay20650 \
+  --remote-root /outputs/methane_plume_observation_train17234_replay20650 \
   --min-samples 10000 \
   --replay real_iad:/path/to/real_iad_train.jsonl:1500 \
   --replay visa:/path/to/visa_train.jsonl:1500 \
@@ -151,10 +151,10 @@ python training/scripts/prepare_modal_training_bundle_with_replay.py \
 This writes:
 
 ```text
-/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/train.local.jsonl
-/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/train.jsonl
-/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/manifest.json
-/path/to/local_bundle_root/methane_plume_context_v6_train17234_replay20650/images/
+/path/to/local_bundle_root/methane_plume_observation_train17234_replay20650/train.local.jsonl
+/path/to/local_bundle_root/methane_plume_observation_train17234_replay20650/train.jsonl
+/path/to/local_bundle_root/methane_plume_observation_train17234_replay20650/manifest.json
+/path/to/local_bundle_root/methane_plume_observation_train17234_replay20650/images/
 ```
 
 `train.local.jsonl` points at local image paths. `train.jsonl` points at the
@@ -169,7 +169,7 @@ After staging `train.jsonl` and its `images/` directory into the Modal volume so
 that this path exists:
 
 ```text
-/outputs/methane_plume_context_v6_train17234_replay20650/train.jsonl
+/outputs/methane_plume_observation_train17234_replay20650/train.jsonl
 ```
 
 run LEAP fine-tune from a checkout with VLM SFT support:
@@ -193,7 +193,7 @@ final eval loss 0.01687
 
 ## Eval Summary
 
-The held-out evals are proxy demo labels, not customer-adjudicated production
+The held-out evals are demo-curated labels, not customer-adjudicated production
 gold.
 
 | Split | Samples | JSON valid | Strict value exact | LLM judge | VLM judge |
@@ -201,14 +201,14 @@ gold.
 | Core | 235 | 100.0% | 94.4% | 0.959 | 0.889 |
 | Stress | 265 | 100.0% | 77.5% | 0.821 | 0.826 |
 
-Known limitation: the `uncertain` class remained weak on stress examples and
-was often over-called as `present`.
+Known limitation: ambiguous plume cases remained the hardest category on stress
+examples and should be strengthened before a customer production deployment.
 
 ## Reproducibility Notes
 
 - This folder documents the checkpoint recipe; it does not make the private
   model or the source datasets public.
-- The final training labels were best-effort demo labels. For a customer or
+- The final training labels were demo-curated labels. For a customer or
   production system, replace them with customer-approved human labels.
 - The rendered context panel is demo metadata. It should not be described as
   independent GIS/source attribution.

--- a/examples/methane-plume-extraction/training/README.md
+++ b/examples/methane-plume-extraction/training/README.md
@@ -37,6 +37,38 @@ The methane rows used the fixed schema in [`schema.yaml`](schema.yaml). Replay
 rows came from other strict-JSON VLM extraction tasks and were mixed in to
 reduce regression on general structured-output behavior.
 
+## Direct Reproduction Path
+
+This recipe is written as the final path. To reproduce the demo checkpoint
+process, start from the schema in this folder and build toward the final bundle
+shape directly:
+
+1. Acquire source imagery from STARCOP and MethaneSET, or replace it with
+   customer-owned imagery that you are allowed to train on.
+2. Render each source observation into the same image contract used by the demo:
+   the methane product, visible/context panel, timestamp, and source context in
+   one image.
+3. Label each rendered image against [`schema.yaml`](schema.yaml) so every row
+   has exactly the schema keys. Do not add intermediate schema versions, nested
+   JSON, or renamed fields.
+4. Write methane labels in the eval-style JSONL contract shown below.
+5. Mix in structured-output replay rows if you want to preserve general JSON
+   extraction behavior.
+6. Run `prepare_modal_training_bundle_with_replay.py` to create the final LEAP
+   message JSONL plus staged images.
+7. Upload `train.jsonl` and `images/` to the Modal volume path used by
+   [`leap_finetune_modal.yaml`](leap_finetune_modal.yaml), then run LEAP
+   fine-tune.
+8. Evaluate the trained checkpoint against held-out core and stress examples
+   before using it in the browser demo.
+
+Because this cookbook does not redistribute derived imagery or the private
+20,650-row JSONL, exact byte-for-byte reproduction requires regenerating those
+assets from licensed sources or using an approved internal copy of the training
+bundle. The process, schema, row format, final mix, and training config are
+documented here so the run can be recreated from the final schema and bundle
+contract.
+
 ## Public Data Sources
 
 The checkpoint was built from public methane remote-sensing sources rendered
@@ -136,6 +168,8 @@ If you already have labels in this local eval-style format:
 you can convert them into the LEAP VLM SFT message format with:
 
 ```bash
+cd examples/methane-plume-extraction
+
 python training/scripts/prepare_modal_training_bundle_with_replay.py \
   --schema training/schema.yaml \
   --labels-jsonl /path/to/methane_train_observation_17234.jsonl \
@@ -160,22 +194,36 @@ This writes:
 `train.local.jsonl` points at local image paths. `train.jsonl` points at the
 Modal volume paths used by the LEAP config.
 
+The helper enforces the final schema directly: every methane row must have
+exactly the keys in `schema.yaml`, and the assistant target is written as a
+compact JSON string.
+
 ## Fine-Tuning With LEAP
 
 The exact config used for the demo checkpoint is
 [`leap_finetune_modal.yaml`](leap_finetune_modal.yaml).
 
-After staging `train.jsonl` and its `images/` directory into the Modal volume so
-that this path exists:
+After staging `train.jsonl` and its `images/` directory into the Modal volume,
+the training container must see this path:
 
 ```text
 /outputs/methane_plume_observation_train17234_replay20650/train.jsonl
 ```
 
-run LEAP fine-tune from a checkout with VLM SFT support:
+If the LEAP Modal app mounts the `leap-finetune` volume at `/outputs`, upload
+the prepared dataset directory to the matching path inside that volume:
 
 ```bash
-leap-finetune examples/methane-plume-extraction/training/leap_finetune_modal.yaml
+modal volume put leap-finetune \
+  /path/to/local_bundle_root/methane_plume_observation_train17234_replay20650 \
+  /methane_plume_observation_train17234_replay20650
+```
+
+Then run LEAP fine-tune from a checkout with VLM SFT support:
+
+```bash
+cd examples/methane-plume-extraction
+leap-finetune training/leap_finetune_modal.yaml
 ```
 
 The demo run used:

--- a/examples/methane-plume-extraction/training/leap_finetune_modal.yaml
+++ b/examples/methane-plume-extraction/training/leap_finetune_modal.yaml
@@ -1,0 +1,39 @@
+project_name: "methane_plume_context_v6_train17234_replay_lfm25vl_modal"
+model_name: "LFM2.5-VL-1.6B"
+training_type: "vlm_sft"
+
+dataset:
+  path: "/outputs/methane_plume_context_v6_train17234_replay20650/train.jsonl"
+  type: "vlm_sft"
+  test_size: 0.02
+
+training_config:
+  extends: "DEFAULT_VLM_SFT"
+  num_train_epochs: 1
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 8
+  learning_rate: 2e-5
+  warmup_ratio: 0.05
+  save_strategy: "epoch"
+  save_total_limit: 2
+  eval_strategy: "epoch"
+  eval_on_start: true
+  logging_first_step: true
+  logging_steps: 50
+  tracker: null
+  gradient_checkpointing: false
+  do_image_splitting: true
+
+peft_config:
+  extends: "DEFAULT_VLM_LORA"
+  use_peft: true
+  r: 16
+  lora_alpha: 32
+
+modal:
+  app_name: "leap-finetune-methane-plume-context-v6-train17234-replay"
+  gpu: "H100:1"
+  timeout: 28800
+  output_volume: "leap-finetune"
+  output_dir: "/outputs"
+  detach: false

--- a/examples/methane-plume-extraction/training/leap_finetune_modal.yaml
+++ b/examples/methane-plume-extraction/training/leap_finetune_modal.yaml
@@ -1,9 +1,9 @@
-project_name: "methane_plume_context_v6_train17234_replay_lfm25vl_modal"
+project_name: "methane_plume_observation_train17234_replay_lfm25vl_modal"
 model_name: "LFM2.5-VL-1.6B"
 training_type: "vlm_sft"
 
 dataset:
-  path: "/outputs/methane_plume_context_v6_train17234_replay20650/train.jsonl"
+  path: "/outputs/methane_plume_observation_train17234_replay20650/train.jsonl"
   type: "vlm_sft"
   test_size: 0.02
 
@@ -31,7 +31,7 @@ peft_config:
   lora_alpha: 32
 
 modal:
-  app_name: "leap-finetune-methane-plume-context-v6-train17234-replay"
+  app_name: "leap-finetune-methane-plume-observation-train17234-replay"
   gpu: "H100:1"
   timeout: 28800
   output_volume: "leap-finetune"

--- a/examples/methane-plume-extraction/training/sample_train_row.json
+++ b/examples/methane-plume-extraction/training/sample_train_row.json
@@ -1,0 +1,32 @@
+{
+  "sample_id": "methane:starcop:ang20191023t162847_r256_c0_w512_h512__vflip",
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {
+          "type": "text",
+          "text": "Extract the following from the image:\n\nmethane_plume_status: Exact methane plume assessment from the rendered image using one of present, absent, or uncertain.\nplume_confidence: Confidence in the plume assessment using one of low, medium, or high.\nplume_extent: Approximate visible plume extent in the methane product using one of none, small, medium, or large.\nplume_location: Approximate visible plume location in the image using one of top_left, top_right, center, bottom_left, bottom_right, or unknown.\nlookalike_risk: Most likely non-methane visual explanation using one of steam, dust, cloud_shadow, surface_artifact, sensor_artifact, albedo_confuser, none, or unknown.\nvisual_evidence_summary: One short image-only sentence describing the visible evidence without source metadata or operational recommendations.\nobservation_timestamp_utc: Observation timestamp shown in the observation context panel as ISO-8601 UTC, or unknown when unavailable.\nsource_context: Supplied source type shown in the observation context panel using one of well_pad, compressor_station, pipeline_corridor, processing_facility, landfill, mine, agriculture, unknown, or not_applicable.\nsource_alignment_assessment: Whether visible plume evidence aligns with supplied source context using one of aligned, source_context_unavailable, no_visible_plume, or unknown.\nreview_priority: Human review priority for the observation using one of low, medium, or high."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "image",
+          "image": "/outputs/methane_plume_context_v6_train17234_replay20650/images/methane/vflip/starcop_ang20191023t162847_r256_c0_w512_h512__vflip.png"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "{\"methane_plume_status\":\"absent\",\"plume_confidence\":\"high\",\"plume_extent\":\"none\",\"plume_location\":\"unknown\",\"lookalike_risk\":\"none\",\"visual_evidence_summary\":\"No coherent plume-like methane enhancement is visible in the methane product panel.\",\"observation_timestamp_utc\":\"2019-10-23T16:28:47Z\",\"source_context\":\"not_applicable\",\"source_alignment_assessment\":\"no_visible_plume\",\"review_priority\":\"low\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/methane-plume-extraction/training/sample_train_row.json
+++ b/examples/methane-plume-extraction/training/sample_train_row.json
@@ -15,7 +15,7 @@
       "content": [
         {
           "type": "image",
-          "image": "/outputs/methane_plume_context_v6_train17234_replay20650/images/methane/vflip/starcop_ang20191023t162847_r256_c0_w512_h512__vflip.png"
+          "image": "/outputs/methane_plume_observation_train17234_replay20650/images/methane/vflip/starcop_ang20191023t162847_r256_c0_w512_h512__vflip.png"
         }
       ]
     },

--- a/examples/methane-plume-extraction/training/schema.yaml
+++ b/examples/methane-plume-extraction/training/schema.yaml
@@ -1,0 +1,10 @@
+methane_plume_status: Exact methane plume assessment from the rendered image using one of present, absent, or uncertain.
+plume_confidence: Confidence in the plume assessment using one of low, medium, or high.
+plume_extent: Approximate visible plume extent in the methane product using one of none, small, medium, or large.
+plume_location: Approximate visible plume location in the image using one of top_left, top_right, center, bottom_left, bottom_right, or unknown.
+lookalike_risk: Most likely non-methane visual explanation using one of steam, dust, cloud_shadow, surface_artifact, sensor_artifact, albedo_confuser, none, or unknown.
+visual_evidence_summary: One short image-only sentence describing the visible evidence without source metadata or operational recommendations.
+observation_timestamp_utc: Observation timestamp shown in the observation context panel as ISO-8601 UTC, or unknown when unavailable.
+source_context: Supplied source type shown in the observation context panel using one of well_pad, compressor_station, pipeline_corridor, processing_facility, landfill, mine, agriculture, unknown, or not_applicable.
+source_alignment_assessment: Whether visible plume evidence aligns with supplied source context using one of aligned, source_context_unavailable, no_visible_plume, or unknown.
+review_priority: Human review priority for the observation using one of low, medium, or high.

--- a/examples/methane-plume-extraction/training/scripts/prepare_modal_training_bundle_with_replay.py
+++ b/examples/methane-plume-extraction/training/scripts/prepare_modal_training_bundle_with_replay.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Prepare a Modal VLM SFT bundle with methane rows plus structured-output replay."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import re
+import shutil
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def compact_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def load_schema(path: Path) -> dict[str, str]:
+    with path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("schema must be a mapping")
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def build_system_prompt(schema: dict[str, str]) -> str:
+    schema_yaml = yaml.safe_dump(schema, sort_keys=False, allow_unicode=True).strip()
+    return f"Extract the following from the image:\n\n{schema_yaml}"
+
+
+def safe_name(text: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "_", text).strip("_")[:140] or "sample"
+
+
+def link_or_copy(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists() and dst.stat().st_size > 0:
+        return
+    if dst.exists():
+        dst.unlink()
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def parse_replay_arg(value: str) -> tuple[str, Path, int]:
+    try:
+        name, path, count = value.split(":", 2)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "replay entries must use name:path:count"
+        ) from exc
+    return name, Path(path), int(count)
+
+
+def extract_assistant_text(row: dict[str, Any]) -> str:
+    messages = row.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return ""
+    content = messages[-1].get("content") if isinstance(messages[-1], dict) else None
+    if isinstance(content, list):
+        return " ".join(str(item.get("text", "")) for item in content if isinstance(item, dict))
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+def validate_message_row(row: dict[str, Any], *, line_label: str) -> None:
+    messages = row.get("messages")
+    if not isinstance(messages, list) or len(messages) < 2:
+        raise ValueError(f"{line_label}: missing messages")
+    assistant_text = extract_assistant_text(row)
+    if not assistant_text:
+        raise ValueError(f"{line_label}: missing assistant text")
+    try:
+        json.loads(assistant_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{line_label}: assistant text is not JSON: {exc}") from exc
+
+
+def rewrite_sample_id(row: dict[str, Any], prefix: str, index: int) -> dict[str, Any]:
+    out = json.loads(json.dumps(row))
+    sample_id = str(out.get("sample_id") or f"row_{index:06d}")
+    out["sample_id"] = f"{prefix}:{sample_id}"
+    return out
+
+
+def minimal_training_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Keep only columns the VLM loader needs.
+
+    Hugging Face's JSON loader infers one Arrow schema for the full JSONL.
+    Mixing methane metadata with replay metadata can introduce different nested
+    structs or extra top-level columns, so the training file must stay minimal.
+    """
+    return {"sample_id": str(row["sample_id"]), "messages": row["messages"]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", required=True)
+    parser.add_argument("--labels-jsonl", required=True)
+    parser.add_argument("--bundle-root", required=True)
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--remote-root", required=True)
+    parser.add_argument("--min-samples", type=int, default=10_000)
+    parser.add_argument("--replay", action="append", type=parse_replay_arg, default=[])
+    parser.add_argument("--seed", type=int, default=20260507)
+    args = parser.parse_args()
+
+    schema_path = Path(args.schema).resolve()
+    labels_path = Path(args.labels_jsonl).resolve()
+    schema = load_schema(schema_path)
+    schema_keys = list(schema)
+    system_prompt = build_system_prompt(schema)
+
+    dataset_dir = Path(args.bundle_root).resolve() / args.dataset_name
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    train_local_path = dataset_dir / "train.local.jsonl"
+    train_remote_path = dataset_dir / "train.jsonl"
+    manifest_path = dataset_dir / "manifest.json"
+
+    rng = random.Random(args.seed)
+    counts: dict[str, Counter[str]] = {
+        "mix_source": Counter(),
+        "augmentation": Counter(),
+        "source_dataset": Counter(),
+        "sensor": Counter(),
+        "methane_plume_status": Counter(),
+    }
+    rows = 0
+    staged_images = 0
+    replay_details: list[dict[str, Any]] = []
+
+    with labels_path.open(encoding="utf-8") as methane_f, train_local_path.open(
+        "w", encoding="utf-8"
+    ) as local_f, train_remote_path.open("w", encoding="utf-8") as remote_f:
+        for line_no, line in enumerate(methane_f, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            image_path = Path(row["image"]).resolve()
+            if not image_path.exists():
+                raise FileNotFoundError(f"line {line_no}: image not found: {image_path}")
+
+            metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+            target = row.get("ground_truth")
+            if set(target) != set(schema_keys):
+                raise ValueError(f"line {line_no}: ground_truth keys do not match schema")
+
+            sample_id = str(metadata.get("sample_id") or row.get("sample_id") or f"methane_{line_no:06d}")
+            augmentation = str(metadata.get("augmentation") or "original")
+            rel_name = f"{safe_name(sample_id)}{image_path.suffix.lower() or '.png'}"
+            relative_image = Path("images") / "methane" / safe_name(augmentation) / rel_name
+            staged_image = dataset_dir / relative_image
+            link_or_copy(image_path, staged_image)
+            staged_images += 1
+
+            ordered_target = {key: target[key] for key in schema_keys}
+
+            def make_messages(image_ref: str) -> dict[str, Any]:
+                return {
+                    "sample_id": f"methane:{sample_id}",
+                    "messages": [
+                        {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+                        {"role": "user", "content": [{"type": "image", "image": image_ref}]},
+                        {"role": "assistant", "content": [{"type": "text", "text": compact_json(ordered_target)}]},
+                    ],
+                }
+
+            local_row = make_messages(str(staged_image))
+            remote_row = make_messages(str(Path(args.remote_root) / relative_image))
+            validate_message_row(remote_row, line_label=f"methane line {line_no}")
+            local_f.write(compact_json(minimal_training_row(local_row)) + "\n")
+            remote_f.write(compact_json(minimal_training_row(remote_row)) + "\n")
+
+            rows += 1
+            counts["mix_source"]["methane"] += 1
+            counts["augmentation"][augmentation] += 1
+            counts["source_dataset"][str(metadata.get("source_dataset") or "unknown")] += 1
+            counts["sensor"][str(metadata.get("sensor") or "")] += 1
+            counts["methane_plume_status"][str(ordered_target.get("methane_plume_status") or "unknown")] += 1
+
+        for replay_name, replay_path, replay_count in args.replay:
+            replay_rows = read_jsonl(replay_path)
+            if len(replay_rows) < replay_count:
+                raise ValueError(f"replay {replay_name}: {len(replay_rows)} rows < requested {replay_count}")
+            selected = rng.sample(range(len(replay_rows)), replay_count)
+            for out_index, source_index in enumerate(selected):
+                replay_row = rewrite_sample_id(replay_rows[source_index], f"replay_{replay_name}", out_index)
+                validate_message_row(replay_row, line_label=f"replay {replay_name} row {source_index}")
+                local_f.write(compact_json(minimal_training_row(replay_row)) + "\n")
+                remote_f.write(compact_json(minimal_training_row(replay_row)) + "\n")
+                rows += 1
+                counts["mix_source"][f"replay_{replay_name}"] += 1
+            replay_details.append(
+                {
+                    "name": replay_name,
+                    "path": str(replay_path),
+                    "path_sha256": sha256_file(replay_path),
+                    "available_rows": len(replay_rows),
+                    "selected_rows": replay_count,
+                }
+            )
+
+    if rows < args.min_samples:
+        raise ValueError(f"prepared {rows} rows, below minimum {args.min_samples}")
+
+    manifest = {
+        "dataset_name": args.dataset_name,
+        "dataset_dir": str(dataset_dir),
+        "remote_root": args.remote_root,
+        "schema": str(schema_path),
+        "schema_sha256": sha256_file(schema_path),
+        "labels_jsonl": str(labels_path),
+        "labels_sha256": sha256_file(labels_path),
+        "train_local_jsonl": str(train_local_path),
+        "train_remote_jsonl": str(train_remote_path),
+        "train_remote_sha256": sha256_file(train_remote_path),
+        "rows": rows,
+        "staged_methane_images": staged_images,
+        "counts": {name: dict(counter) for name, counter in counts.items()},
+        "replay": replay_details,
+        "notes": [
+            "Methane rows use the supplied flat schema in canonical key order.",
+            "Replay rows are pre-existing strict-JSON structured-output VLM tasks and keep their own prompts/schemas.",
+            "Replay image paths are expected to already exist under /outputs in the Modal volume.",
+        ],
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/methane-plume-extraction/training/scripts/prepare_modal_training_bundle_with_replay.py
+++ b/examples/methane-plume-extraction/training/scripts/prepare_modal_training_bundle_with_replay.py
@@ -128,7 +128,7 @@ def main() -> int:
     parser.add_argument("--remote-root", required=True)
     parser.add_argument("--min-samples", type=int, default=10_000)
     parser.add_argument("--replay", action="append", type=parse_replay_arg, default=[])
-    parser.add_argument("--seed", type=int, default=20260507)
+    parser.add_argument("--seed", type=int, default=1234)
     args = parser.parse_args()
 
     schema_path = Path(args.schema).resolve()

--- a/examples/methane-plume-extraction/training/training_manifest.json
+++ b/examples/methane-plume-extraction/training/training_manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact": "felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo",
   "base_model": "LiquidAI/LFM2.5-VL-1.6B",
-  "created_from_local_manifest": "methane_plume_context_v6_train17234_replay20650/manifest.json",
-  "schema_version": "methane_plume_context_v6_observation_panel",
+  "created_from_local_manifest": "final training manifest summarized for cookbook",
+  "schema_version": "methane_plume_observation_panel",
   "dataset": {
-    "name": "methane_plume_context_v6_train17234_replay20650",
-    "train_jsonl_modal_path": "/outputs/methane_plume_context_v6_train17234_replay20650/train.jsonl",
+    "name": "methane_plume_observation_train17234_replay20650",
+    "train_jsonl_modal_path": "/outputs/methane_plume_observation_train17234_replay20650/train.jsonl",
     "train_jsonl_sha256": "b95c62e532769f8070fd1dcaa94e5207e8392389194f8f7add63ec36fc84e904",
     "schema_sha256": "dd7ddbdf57b272e71e29c6a86af98156bf2f158f5a244880300fe0de43066cfe",
     "methane_labels_sha256": "97a439af58bf985a23fa6505fcae2237affd44af02030232d2a71b446b4eb3fa",
@@ -98,7 +98,7 @@
     "final_eval_loss": 0.01687
   },
   "eval": {
-    "caveat": "Eval labels are best-effort demo labels, not customer-verified production gold.",
+    "caveat": "Eval labels are demo-curated labels, not customer-verified production gold.",
     "core": {
       "rows": 235,
       "sha256": "de304f47361ec7b65d1a484f9c2f6b91f80bda86884960aa4a88f7977fd90b29",
@@ -120,6 +120,6 @@
     "Source imagery and derived rendered products are not redistributed in this cookbook example.",
     "Check source dataset licenses before redistributing any rendered images or derived labels.",
     "The checkpoint is a controlled demo artifact, not a regulatory methane quantification system.",
-    "The uncertain class remained weak in stress evaluation and should be improved before open bring-your-own-image demos."
+    "Ambiguous plume cases remained the hardest category and should be improved before open bring-your-own-image demos."
   ]
 }

--- a/examples/methane-plume-extraction/training/training_manifest_context_v6.json
+++ b/examples/methane-plume-extraction/training/training_manifest_context_v6.json
@@ -1,0 +1,125 @@
+{
+  "artifact": "felipeliquid/LFM2.5-1.6B-VL-Extract-Plume-Demo",
+  "base_model": "LiquidAI/LFM2.5-VL-1.6B",
+  "created_from_local_manifest": "methane_plume_context_v6_train17234_replay20650/manifest.json",
+  "schema_version": "methane_plume_context_v6_observation_panel",
+  "dataset": {
+    "name": "methane_plume_context_v6_train17234_replay20650",
+    "train_jsonl_modal_path": "/outputs/methane_plume_context_v6_train17234_replay20650/train.jsonl",
+    "train_jsonl_sha256": "b95c62e532769f8070fd1dcaa94e5207e8392389194f8f7add63ec36fc84e904",
+    "schema_sha256": "dd7ddbdf57b272e71e29c6a86af98156bf2f158f5a244880300fe0de43066cfe",
+    "methane_labels_sha256": "97a439af58bf985a23fa6505fcae2237affd44af02030232d2a71b446b4eb3fa",
+    "rows_total": 20650,
+    "methane_rows": 17234,
+    "replay_rows": 3416,
+    "counts": {
+      "methane_plume_status": {
+        "absent": 5750,
+        "present": 9734,
+        "uncertain": 1750
+      },
+      "source_dataset": {
+        "starcop": 10904,
+        "methaneset": 6146,
+        "unknown_or_context_extra": 184
+      },
+      "sensor": {
+        "starcop_or_unspecified": 11088,
+        "landsat89": 3122,
+        "sentinel2": 3024
+      },
+      "source_context": {
+        "not_applicable": 5750,
+        "unknown": 3430,
+        "well_pad": 3070,
+        "landfill": 945,
+        "mine": 839,
+        "agriculture": 800,
+        "processing_facility": 800,
+        "pipeline_corridor": 800,
+        "compressor_station": 800
+      },
+      "augmentation": {
+        "original": 7248,
+        "hflip": 6980,
+        "vflip": 1062,
+        "hvflip": 1055,
+        "contrast": 236,
+        "hflip_contrast": 229,
+        "hvflip_contrast": 217,
+        "vflip_contrast": 207
+      },
+      "mix_source": {
+        "methane": 17234,
+        "replay_real_iad": 1500,
+        "replay_visa": 1500,
+        "replay_forge": 416
+      }
+    },
+    "replay": [
+      {
+        "name": "real_iad",
+        "selected_rows": 1500,
+        "available_rows": 5000,
+        "path_sha256": "cc34948e0145881f848bf32c7c337ba6bca51bf3947e5bce3198f04f26b7d8d6"
+      },
+      {
+        "name": "visa",
+        "selected_rows": 1500,
+        "available_rows": 10321,
+        "path_sha256": "e8c6d16aa1675351b24775863ea822f7a71a506d8d61cbbd87c568bf71a8b53b"
+      },
+      {
+        "name": "forge",
+        "selected_rows": 416,
+        "available_rows": 666,
+        "path_sha256": "95862c66dca214ae9106424e5e31004611e0d463059f5c5e9ae57324bd002ce0"
+      }
+    ],
+    "notes": [
+      "The JSONL used for training is intentionally minimal: sample_id plus messages.",
+      "Methane rows use one system prompt containing the fixed flat schema, one image message, and one assistant JSON string.",
+      "The 184 unknown_or_context_extra rows are context-augmented rows whose source_dataset field was not normalized in the original manifest; most were MethaneSET EMIT-derived context examples.",
+      "Replay rows are strict-JSON structured-output VLM tasks from other examples and are mixed in to reduce regression on general extraction behavior."
+    ]
+  },
+  "training": {
+    "method": "LEAP VLM SFT with LoRA, merged after training",
+    "epochs": 1,
+    "steps": 2529,
+    "learning_rate": 0.00002,
+    "per_device_train_batch_size": 1,
+    "gradient_accumulation_steps": 8,
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "hardware": "1x NVIDIA H100 on Modal",
+    "runtime": "1h 28m 47s after data upload",
+    "final_train_loss": 0.04211,
+    "final_eval_loss": 0.01687
+  },
+  "eval": {
+    "caveat": "Eval labels are best-effort demo labels, not customer-verified production gold.",
+    "core": {
+      "rows": 235,
+      "sha256": "de304f47361ec7b65d1a484f9c2f6b91f80bda86884960aa4a88f7977fd90b29",
+      "json_valid": "100.0%",
+      "strict_value_exact": "94.4%",
+      "llm_judge": 0.959,
+      "vlm_judge": 0.889
+    },
+    "stress": {
+      "rows": 265,
+      "sha256": "07914d9c147a346ed435f852b65e4eafc3c0a9b762f8ac483882101aefba9d62",
+      "json_valid": "100.0%",
+      "strict_value_exact": "77.5%",
+      "llm_judge": 0.821,
+      "vlm_judge": 0.826
+    }
+  },
+  "public_release_caveats": [
+    "Source imagery and derived rendered products are not redistributed in this cookbook example.",
+    "Check source dataset licenses before redistributing any rendered images or derived labels.",
+    "The checkpoint is a controlled demo artifact, not a regulatory methane quantification system.",
+    "The uncertain class remained weak in stress evaluation and should be improved before open bring-your-own-image demos."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a self-contained methane plume extraction cookbook example for O&G leak-monitoring triage with `LFM2.5-VL-1.6B`.

The example shows the structured-output workflow:

```text
rendered methane observation image + fixed customer schema -> JSON record
```

It includes:

- a browser demo with curated methane plume samples and ground-truth assessment
- local base/fine-tuned model inference servers
- the exact fixed methane schema and prompt shape
- Hugging Face model access/download instructions
- agent runbooks for opening and validating the demo
- a `training/` recipe that documents how the private checkpoint was produced and how to reproduce the final recipe directly

## Fine-tuning recipe

Added `examples/methane-plume-extraction/training/` with:

- `schema.yaml`: exact schema used for the checkpoint
- `leap_finetune_modal.yaml`: LEAP VLM SFT config used for the run
- `training_manifest.json`: verified final dataset mix, checksums, hyperparameters, and eval results
- `sample_train_row.json`: concrete LEAP VLM SFT message-format example
- `scripts/prepare_modal_training_bundle_with_replay.py`: helper to convert image/schema/ground-truth rows into the Modal/LEAP training JSONL format

The documented checkpoint recipe is:

- 20,650 rows total
- 17,234 methane/context rows
- 3,416 structured-output replay rows
- 1 epoch, LoRA r=16 / alpha=32, LR 2e-5
- 1x H100 on Modal, 1h 28m 47s after data upload

The cookbook does not redistribute source imagery, rendered train images, or the full 20,650-row JSONL. The training README points users to the public sources, the required final schema, the expected row contract, the Modal upload path, and the license constraints before redistributing derivatives.

## Data sources

- STARCOP / AVIRIS-NG style methane plume products
- MethaneSET Sentinel-2, Landsat 8/9, and EMIT-derived examples
- JPL AVIRIS-NG CH4/CO2 benchmark used for source/eval exploration and held-out demo evaluation, not claimed as a final training source
- Replay rows from other strict-JSON structured-output VLM tasks to reduce regression

## Validation

- `python3 -m py_compile examples/methane-plume-extraction/scripts/serve_demo.py examples/methane-plume-extraction/scripts/serve_local_methane.py examples/methane-plume-extraction/training/scripts/prepare_modal_training_bundle_with_replay.py`
- `python3 -m json.tool` on `training_manifest.json` and `sample_train_row.json`
- Parsed the embedded `interactive_demo.html` payload as JSON
- Verified demo and training `schema.yaml` files are byte-identical and match `training_manifest.json`
- Checked public-facing text for stale internal labels or dataset names
- Checked the final reproduction path includes schema, label row contract, bundle helper, Modal volume upload target, LEAP config, and eval caveat
- Secret/weight scan: no tokens, `.env`, model weights, caches, pyc files, or local absolute paths included

