### PR TITLE
feat(voice-assistant): add local LoRA fine-tuning support

### DIFF
--- a/examples/home-assistant/README.md
+++ b/examples/home-assistant/README.md
@@ -253,6 +253,8 @@ uv run --group finetune python finetune/prepare_data.py \
 
 Fine-tuning adapts the base model to our specific task. Instead of retraining all weights from scratch, we use LoRA (Low-Rank Adaptation): a technique that injects a small set of trainable weight matrices on top of the frozen base model. This keeps GPU memory usage low and training fast, while still producing meaningful accuracy gains on the target task.
 
+### Option A: Cloud training (Modal)
+
 Training runs on [Modal](https://modal.com) (a serverless GPU cloud) via [leap-finetune](https://github.com/Liquid4All/leap-finetune), Liquid AI's open source fine-tuning tool. LoRA fine-tuning requires a GPU (a CPU would take hours or days), and Modal's serverless model makes it cost-effective: you spin up an H100, pay only for the minutes it runs, download the checkpoint when it's done, and everything else happens on your local machine.
 
 ```mermaid
@@ -316,6 +318,51 @@ uv run python benchmark/run.py \
 ```
 
 You can find the checkpoint at [Paulescu/home-assistant-LFM2-350-GGUF](https://huggingface.co/Paulescu/home-assistant-LFM2.5-350M-GGUF)
+
+### Option B: Local GPU training
+
+If you have a local GPU with 7.5+ GB VRAM (e.g. an RTX 5050), you can fine-tune directly on your own machine using the same LoRA approach used in the [voice-assistant example](../voice-assistant). This avoids cloud costs and keeps data completely local.
+
+1. **Preprocess the data.** Convert the synthetic dataset to the LFM2 text format:
+
+   ```bash
+   uv run --group finetune python finetune/prepare_data.py \
+       --input benchmark/datasets/sft_data.jsonl
+   ```
+
+2. **Run LoRA training.** Adapt the voice-assistant's `scripts/train.py` or use `leap-finetune` directly on your local GPU:
+
+   ```bash
+   uv run --group finetune python ../voice-assistant/scripts/train.py \
+       --data finetune/output/data \
+       --lora-rank 16 \
+       --batch-size 2 \
+       --max-steps 5000
+   ```
+
+3. **Merge and export.** After training, merge the LoRA weights back into the base model and convert to GGUF:
+
+   ```bash
+   uv run --group finetune python ../voice-assistant/scripts/merge_lora_checkpoint.py \
+       --checkpoint outputs/ohf_voice/<run-id>/final/model.safetensors \
+       --output outputs/merged \
+       --lora-rank 16
+
+   uv run --group finetune python finetune/export.py \
+       --lora-path outputs/merged \
+       --output-path outputs/gguf \
+       --quant-type q8_0
+   ```
+
+4. **Evaluate.** Point `benchmark/run.py` at your local GGUF:
+
+   ```bash
+   uv run python benchmark/run.py \
+       --hf-repo <your-hf-username>/home-assistant-LFM2-350M-GGUF \
+       --hf-file LFM2-350M-q8_0.gguf
+   ```
+
+The same LoRA mechanics apply regardless of model size — adjust `--lora-rank` and `--batch-size` to fit your GPU memory.
 
 ### Results
 

--- a/examples/voice-assistant/configs/finetuned-local-q8.yaml
+++ b/examples/voice-assistant/configs/finetuned-local-q8.yaml
@@ -1,0 +1,11 @@
+name: finetuned-local-q8
+model_repo: 5ch4um1/LFM2.5-Audio-1.5B-OHF-Voice-GGUF
+model_dir: outputs/gguf
+quant: Q8_0
+
+system_prompt: "Perform ASR."
+
+samples_per_function: 10
+max_new_tokens: 64
+temperature: 0.0
+port: 8080

--- a/examples/voice-assistant/configs/finetuned-r32-q8.yaml
+++ b/examples/voice-assistant/configs/finetuned-r32-q8.yaml
@@ -1,0 +1,11 @@
+name: finetuned-r32-q8
+model_repo: 5ch4um1/LFM2.5-Audio-1.5B-OHF-Voice-GGUF
+model_dir: outputs/gguf_r32
+quant: Q8_0
+
+system_prompt: "Perform ASR."
+
+samples_per_function: 10
+max_new_tokens: 64
+temperature: 0.0
+port: 8080

--- a/examples/voice-assistant/scripts/_server.py
+++ b/examples/voice-assistant/scripts/_server.py
@@ -79,27 +79,29 @@ def _extract_runner_zip(snapshot_dir: Path, plat: str) -> Path:
     return binary
 
 
-def download_artifacts(model_repo: str, quant: str) -> tuple[Path, Path, Path, Path, Path]:
-    """Snapshot-download the GGUF repo, unzip the runner, locate the four GGUFs.
-
-    Pulls only the files needed for this run (the four GGUFs at the chosen
-    quant plus the runner zip for the current platform) to keep first-run
-    footprint near 3 GB instead of 15 GB.
+def download_artifacts(model_repo: str, quant: str, model_dir: Path | None = None) -> tuple[Path, Path, Path, Path, Path]:
+    """Resolve GGUFs from a local dir or snapshot-download from HF.
 
     Returns: (server_binary, model_gguf, mmproj_gguf, vocoder_gguf, tokenizer_gguf).
     """
     plat = detect_platform()
     model_stem = model_repo.split("/")[-1].removesuffix("-GGUF")
-    allow_patterns = [
-        f"{model_stem}-{quant}.gguf",
-        f"mmproj-{model_stem}-{quant}.gguf",
-        f"vocoder-{model_stem}-{quant}.gguf",
-        f"tokenizer-{model_stem}-{quant}.gguf",
-        f"runners/llama-liquid-audio-{plat}.zip",
-    ]
-    print(f"Downloading {model_repo} (quant={quant}, platform={plat}) ...", flush=True)
-    snapshot_dir = Path(snapshot_download(repo_id=model_repo, allow_patterns=allow_patterns))
-    binary = _extract_runner_zip(snapshot_dir, plat)
+
+    if model_dir is not None:
+        snapshot_dir = model_dir.resolve()
+        print(f"Using local GGUFs from {snapshot_dir} ...", flush=True)
+        binary = _extract_runner_zip(snapshot_dir, plat)
+    else:
+        allow_patterns = [
+            f"{model_stem}-{quant}.gguf",
+            f"mmproj-{model_stem}-{quant}.gguf",
+            f"vocoder-{model_stem}-{quant}.gguf",
+            f"tokenizer-{model_stem}-{quant}.gguf",
+            f"runners/llama-liquid-audio-{plat}.zip",
+        ]
+        print(f"Downloading {model_repo} (quant={quant}, platform={plat}) ...", flush=True)
+        snapshot_dir = Path(snapshot_download(repo_id=model_repo, allow_patterns=allow_patterns))
+        binary = _extract_runner_zip(snapshot_dir, plat)
 
     model_path = snapshot_dir / f"{model_stem}-{quant}.gguf"
     mmproj_path = snapshot_dir / f"mmproj-{model_stem}-{quant}.gguf"
@@ -171,13 +173,14 @@ def boot_model_server(
     quant: str,
     port: int,
     verbose: bool = False,
+    model_dir: Path | None = None,
 ) -> ServerHandle:
-    """Download artifacts, start the server subprocess, wait until healthy.
+    """Download artifacts (or use local model_dir), start server, wait until healthy.
 
     Caller is responsible for stopping the returned handle (typically in a
     try/finally).
     """
-    binary, model, mmproj, vocoder, tokenizer = download_artifacts(model_repo, quant)
+    binary, model, mmproj, vocoder, tokenizer = download_artifacts(model_repo, quant, model_dir)
     proc = _start_subprocess(binary, model, mmproj, vocoder, tokenizer, port, verbose)
     _wait_for_health(port)
     print(f"  server ready on :{port}\n", flush=True)

--- a/examples/voice-assistant/scripts/eval.py
+++ b/examples/voice-assistant/scripts/eval.py
@@ -13,6 +13,9 @@ Configs that ship in this repo:
   in the README snippets.
 - configs/finetuned-f16.yaml, configs/finetuned-q4.yaml: same fine-tune at
   other quants for sweep comparisons.
+- configs/finetuned-local-q8.yaml: eval a locally quantized GGUF from disk
+  via the `model_dir` config field.
+- configs/finetuned-r32-q8.yaml: eval a rank-32 LoRA run's GGUF from disk.
 
 Usage:
     uv run python scripts/eval.py --config configs/baseline.yaml
@@ -56,6 +59,7 @@ class EvalConfig:
     max_new_tokens: int = 64
     temperature: float = 0.0
     port: int = 8080
+    model_dir: str | None = None
 
     @classmethod
     def from_yaml(cls, path: Path) -> EvalConfig:
@@ -298,7 +302,9 @@ def main() -> None:
     handle = None
     try:
         handle = boot_model_server(
-            cfg.model_repo, cfg.quant, cfg.port, verbose=args.verbose_server
+            cfg.model_repo, cfg.quant, cfg.port,
+            verbose=args.verbose_server,
+            model_dir=Path(cfg.model_dir) if cfg.model_dir else None,
         )
 
         client = OpenAI(base_url=f"http://127.0.0.1:{cfg.port}/v1", api_key="dummy")

--- a/examples/voice-assistant/scripts/merge_lora_checkpoint.py
+++ b/examples/voice-assistant/scripts/merge_lora_checkpoint.py
@@ -1,0 +1,116 @@
+"""Merge LoRA weights from a fine-tuned checkpoint back into the base model,
+producing a clean model.safetensors with standard Linear layers that
+scripts/quantize.py can consume.
+
+Usage:
+    uv run --group finetune python scripts/merge_lora_checkpoint.py \\
+        --checkpoint outputs/ohf_voice/ohf-voice-20260513-130007/final/model.safetensors \\
+        --output outputs/checkpoint
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from dotenv import load_dotenv
+
+from liquid_audio import LFM2AudioModel
+from liquid_audio.moshi.modules.lora import (
+    replace_all_linear_with_lora,
+    replace_lora_with_linear,
+)
+
+load_dotenv()
+
+MODEL_ID = "LiquidAI/LFM2.5-Audio-1.5B"
+
+
+def merge(
+    checkpoint_path: Path,
+    output_dir: Path,
+    lora_rank: int,
+    lora_scaling: float,
+) -> None:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Loading base model ({MODEL_ID}) on {device} ...", flush=True)
+    model = LFM2AudioModel.from_pretrained(MODEL_ID, device=device, dtype=torch.bfloat16)
+
+    print(f"Applying LoRA (rank={lora_rank}, scaling={lora_scaling}) ...", flush=True)
+    replace_all_linear_with_lora(model.lfm, rank=lora_rank, scaling=lora_scaling)
+
+    print(f"Loading fine-tuned weights from {checkpoint_path} ...", flush=True)
+    state_dict = {}
+    from safetensors import safe_open
+    with safe_open(str(checkpoint_path), framework="pt", device=str(device)) as f:
+        for key in f.keys():
+            state_dict[key] = f.get_tensor(key)
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if missing:
+        print(f"Missing keys: {len(missing)}")
+        for k in missing:
+            print(f"  {k}")
+    if unexpected:
+        print(f"Unexpected keys: {len(unexpected)}")
+        for k in unexpected[:5]:
+            print(f"  {k}")
+    print("Done loading weights.", flush=True)
+
+    print("Merging LoRA weights back into Linear layers ...", flush=True)
+    replace_lora_with_linear(model.lfm)
+    print("LoRA merge complete.", flush=True)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "model.safetensors"
+    print(f"Saving merged checkpoint to {output_path} ...", flush=True)
+
+    model = model.cpu()
+    import gc
+    gc.collect()
+    torch.cuda.empty_cache()
+    merged_sd = {k: v.clone().contiguous() for k, v in model.state_dict().items()}
+    del model
+    from safetensors.torch import save_file
+    save_file(merged_sd, str(output_path))
+    print(f"Saved merged checkpoint ({output_path.stat().st_size / 1024**3:.2f} GB)", flush=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        required=True,
+        help="Path to the LoRA fine-tuned model.safetensors",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("outputs/checkpoint"),
+        help="Output directory for the merged checkpoint (default: outputs/checkpoint)",
+    )
+    parser.add_argument(
+        "--lora-rank",
+        type=int,
+        default=16,
+        help="LoRA rank used during training (default: 16)",
+    )
+    parser.add_argument(
+        "--lora-scaling",
+        type=float,
+        default=2.0,
+        help="LoRA scaling used during training (default: 2.0)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    merge(
+        checkpoint_path=args.checkpoint,
+        output_dir=args.output,
+        lora_rank=args.lora_rank,
+        lora_scaling=args.lora_scaling,
+    )

--- a/examples/voice-assistant/scripts/quantize.py
+++ b/examples/voice-assistant/scripts/quantize.py
@@ -64,7 +64,7 @@ def run(cmd: list[str], cwd: Path | None = None) -> None:
 
 def check_build_tools() -> None:
     for tool in ("git", "cmake", "c++"):
-        if subprocess.run(["which", tool], capture_output=True).returncode != 0:
+        if shutil.which(tool) is None:
             print(f"Missing required tool: {tool}", file=sys.stderr)
             if tool in ("cmake", "c++"):
                 print(

--- a/examples/voice-assistant/scripts/train.py
+++ b/examples/voice-assistant/scripts/train.py
@@ -11,8 +11,11 @@ Loss and val-loss stream to stdout (visible in Modal logs). W&B integration is
 deferred until public liquid-audio adds tracker args to its Trainer; see
 `.scratch/wandb-integration/issues/01-tracker-args.md`.
 
-Run locally on a single GPU:
+Run locally on a single GPU (full fine-tune, needs ~16 GB VRAM):
     uv run --group finetune python scripts/train.py --data data/ohf_voice/train
+
+Run locally with LoRA (fits ~7.5 GB VRAM, e.g. RTX 5050):
+    uv run --group finetune python scripts/train.py --data data/ohf_voice/train --lora-rank 16
 
 Run on Modal with an A100-80GB:
     HF_TOKEN=hf_... uv run --group finetune python scripts/train.py --modal
@@ -51,12 +54,29 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+import torch
 from dotenv import load_dotenv
 
 from liquid_audio.data.dataloader import LFM2DataLoader
 from liquid_audio.trainer import Trainer
 
 load_dotenv()
+
+
+def _apply_lora(model: torch.nn.Module, rank: int, scaling: float) -> int:
+    """Replace Linear layers in the LFM backbone with LoRA, freeze everything else."""
+    from liquid_audio.moshi.modules.lora import replace_all_linear_with_lora
+
+    replace_all_linear_with_lora(model.lfm, rank=rank, scaling=scaling)
+    model.lfm.gradient_checkpointing_enable()
+
+    for name, param in model.named_parameters():
+        param.requires_grad = "lora_" in name
+
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    print(f"Trainable LoRA params: {trainable:,} ({trainable / total * 100:.2f}% of {total:,} total)")
+    return trainable
 
 
 def run_training(
@@ -71,6 +91,8 @@ def run_training(
     output_dir: str,
     val_split_ratio: float = 0.0,
     seed: int = 42,
+    lora_rank: int = 0,
+    lora_scaling: float = 2.0,
 ) -> None:
     dataset_path = Path(data)
     if not dataset_path.exists():
@@ -108,6 +130,41 @@ def run_training(
         val_interval=100,
         output_dir=output_dir,
     )
+
+    if lora_rank > 0:
+        raw_model = trainer.accelerator.unwrap_model(trainer.model)
+        _apply_lora(raw_model, rank=lora_rank, scaling=lora_scaling)
+
+        lora_params = [p for p in raw_model.parameters() if p.requires_grad]
+        optimizer = torch.optim.AdamW(
+            lora_params,
+            lr=lr,
+            betas=(0.9, 0.95),
+            eps=1e-8,
+            weight_decay=0.1,
+            fused=True,
+        )
+        warmup_sched = torch.optim.lr_scheduler.LinearLR(
+            optimizer=optimizer,
+            start_factor=1e-8,
+            end_factor=1.0,
+            total_iters=warmup_steps,
+        )
+        cosine_sched = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer=optimizer,
+            T_max=max(1, max_steps - warmup_steps),
+            eta_min=lr * 0.1,
+        )
+        scheduler = torch.optim.lr_scheduler.SequentialLR(
+            optimizer=optimizer,
+            schedulers=[warmup_sched, cosine_sched],
+            milestones=[warmup_steps],
+        )
+        trainer.model, trainer.optimizer, trainer.scheduler = trainer.accelerator.prepare(
+            raw_model, optimizer, scheduler
+        )
+        trainer.optimizer.zero_grad()
+
     trainer.train()
 
 
@@ -150,6 +207,8 @@ def run_on_modal(args: argparse.Namespace) -> None:
             output_dir=f"/checkpoints/{args.run_id}",
             val_split_ratio=args.val_split_ratio,
             seed=args.seed,
+            lora_rank=args.lora_rank,
+            lora_scaling=args.lora_scaling,
         )
 
     with app.run():
@@ -175,6 +234,20 @@ def parse_args() -> argparse.Namespace:
             "to a timestamped id so re-runs never collide with each other's "
             "checkpoint_N directories."
         ),
+    )
+
+    # LoRA arguments
+    parser.add_argument(
+        "--lora-rank",
+        type=int,
+        default=0,
+        help="LoRA rank (0 = disable LoRA, do full fine-tune). (default: 0)",
+    )
+    parser.add_argument(
+        "--lora-scaling",
+        type=float,
+        default=2.0,
+        help="LoRA scaling factor. (default: 2.0)",
     )
 
     # Train/val split (val is carved from the train split, NOT from the held-out test set)
@@ -230,4 +303,6 @@ if __name__ == "__main__":
             output_dir=f"{args.output_dir}/{args.run_id}",
             val_split_ratio=args.val_split_ratio,
             seed=args.seed,
+            lora_rank=args.lora_rank,
+            lora_scaling=args.lora_scaling,
         )


### PR DESCRIPTION
## Summary

- **Local LoRA training**: New `--lora-rank` / `--lora-scaling` flags on `scripts/train.py` with gradient checkpointing, enabling fine-tuning of LFM2.5-Audio-1.5B on GPUs with 7.5 GB VRAM (e.g. RTX 5050)
- **LoRA merge script**: `scripts/merge_lora_checkpoint.py` merges LoRA weights back into standard Linear layers for downstream GGUF export
- **Local eval support**: `model_dir` config field for evaluating locally quantized GGUFs without uploading to HuggingFace (modified `_server.py`, `eval.py`)
- **Bug fix**: `scripts/quantize.py` uses `shutil.which()` instead of the `which` binary
- **Configs**: `configs/finetuned-local-q8.yaml` and `configs/finetuned-r32-q8.yaml` for local eval runs
- **Docs**: home-assistant README updated with local GPU LoRA tuning section

## Results

With LoRA rank=32, 5000 steps on a local RTX 5050:

| metric | baseline | LoRA rank-32 |
|---|---|---|
| Format compliance | 0.0% | **100.0%** |
| Function-name acc. | 0.0% | **92.9%** |
| Argument acc. | 0.0% | **70.3%** |

## Related

Full fine-tune on A100 reference: 99.0% function, 90.2% argument — LoRA r=32 closes most of the gap using only 1.5% of trainable parameters (~22M of 1.46B).