### PR TITLE
docs: add Liquid Lens (on-board satellite water monitoring) to End-to-End projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open-source projects built by the community showcasing LFMs with real use cases.
 | Liquid-CLI | Fine-tune and run Liquid AI's LFM2-8B-A1B as a local terminal agent | [Code](https://github.com/gyunggyung/Liquid-CLI) |
 | LFM Podcast Studio | Turn any PDF into a two-host podcast episode locally using LFM2.5-Audio TTS via llama.cpp | [Code](https://github.com/nikhilprasanth/LFM-Podcast-Studio) |
 | GalamseyWatch | Two-layer agentic Earth observation over Sentinel-2 imagery for illegal mining detection in Ghana, powered by LFM2.5-VL-450M and LFM2-2.6B | [Code](https://github.com/samadon1/GalamseyWatch) |
+| Liquid Lens | Detects water anomalies in orbit by combining fast spectral filtering with conditional LFM2.5-VL visual insights on the SimSat orbital simulator | [Code](https://github.com/LiquidLensSystems/water-vlm) |
 
 ## 🕐 Technical Deep Dives
 


### PR DESCRIPTION
### Summary
Adds **Liquid Lens** (`water-vlm`) to the End-to-End Projects directory. 

### Project Overview
An on-board satellite data triage pipeline built on the **DPhi Space SimSat simulator API** to handle orbital downlink bottlenecks. 

- **Tier 1 (Spectral Math):** Evaluates multi-spectral indices (NDWI, NDTI, NDCI, NIR) locally via Docker to drop normal observations without using a GPU.
- **Tier 2 (Conditional VLM):** Triggers `LFM2.5-VL-450M` (via `llama-server` GGUF) only upon anomaly detection to compress visual insights into a small natural-language text block for low-bandwidth transmission.

**Project Link:** https://github.com/LiquidLensSystems/water-vlm

### Type of Change
- [x] Documentation update (non-breaking change adding community project)