### PR TITLE
feat(localcowork): default to LFM2.5-8B-A1B (Q4_K_M)

### DIFF
--- a/examples/localcowork/CLAUDE.md
+++ b/examples/localcowork/CLAUDE.md
@@ -323,3 +323,17 @@ PROGRESS.yaml                      # Persistent progress state (the "JIRA board"
 .claude/commands/session-end.md    # Slash command to checkpoint a session
 .git/hooks/pre-commit              # Guardrail: warns if PROGRESS.yaml not updated
 ```
+
+## Agent skills
+
+### Issue tracker
+
+Local markdown under `.scratch/<feature-slug>/`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles recorded as `Status:` lines in each issue file, using the default strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. `CONTEXT.md` at the LocalCowork root; ADRs at `docs/architecture-decisions/` (not the default `docs/adr/`). See `docs/agents/domain.md`.

--- a/examples/localcowork/CLAUDE.md
+++ b/examples/localcowork/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working on the LocalCowork proje
 
 ## Project Overview
 
-LocalCowork is a desktop AI agent that runs entirely on-device. It delivers a Claude Cowork-style experience powered by a locally-hosted LLM (dev: GPT-OSS-20B via Ollama, production: LFM2-24B-A2B via llama.cpp). The model calls pre-built tools via MCP — it never writes code. The user confirms every mutable action.
+LocalCowork is a desktop AI agent that runs entirely on-device. It delivers a Claude Cowork-style experience powered by a locally-hosted LLM (dev: GPT-OSS-20B via Ollama, production: LFM2.5-8B-A1B via llama.cpp). The model calls pre-built tools via MCP — it never writes code. The user confirms every mutable action.
 
 **Source of truth:** `docs/PRD.md` (the full product requirements document).
 **Tool contract:** `docs/mcp-tool-registry.yaml` (machine-readable tool definitions extracted from the PRD Appendix).

--- a/examples/localcowork/PROGRESS.yaml
+++ b/examples/localcowork/PROGRESS.yaml
@@ -25,9 +25,9 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 project: LocalCowork
-last_updated: "2026-02-18"
-last_session_id: "session-034"
-current_phase: "Post-A/B-test documentation consolidation. Orchestrator operational for 1-2 step workflows (A/B tested). Fine-tuned router V2 at 84% live accuracy. Documentation restructured: 3 files deleted, 1 created, 5 rewritten. All cross-references verified (35 links, 0 broken). Next: commit all changes, run tests."
+last_updated: "2026-05-21"
+last_session_id: "session-035"
+current_phase: "Branch localcowork-lfm2.5-8b-a1b: LFM2.5-8B-A1B is the new default model. Conversion script, parser <think>-prefix tests, model config + start-model.sh --model flag, model-analysis stub, README/CLAUDE.md updates all landed. Branch is non-mergeable to main until LiquidAI publishes the public GGUF repo; curated-tool-surface benchmark on the 8B deliberately deferred."
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # PHASE 0: FOUNDATION (Week 1)
@@ -1784,6 +1784,29 @@ sessions:
       - "docs/model-analysis/lfm2-24b-a2b-real-world-execution.md (360 lines)"
     doc_sync: "✓ cross-refs (35 links, 0 broken), ✓ ADR-009 updated, ✓ README updated, no code changes (docs-only session)"
     next_recommended: "Commit all session-034 changes. Then live manual test of demo presets with running model, or proceed to fine-tuning V3 training data (address security.encrypt_file false positive and cross-server confusion failures)."
+
+  - id: "session-035"
+    date: "2026-05-21"
+    branch: "localcowork-lfm2.5-8b-a1b"
+    focus: "Add LFM2.5-8B-A1B as default model"
+    completed:
+      - "Issue 01 (.scratch/lfm25-8b-a1b-support/issues/01-write-conversion-script.md): wrote scripts/convert-8b-a1b.sh — converts the private safetensors checkpoint to F16/Q8_0/Q4_K_M GGUFs, spawns llama-server, validates response contains <think> block + parseable bracket tool call, optionally uploads Q4_K_M and Q8_0 (only) to Paulescu/LFM2.5-8B-A1B-GGUF via huggingface-cli; F16 deliberately not uploaded"
+      - "Issue 02 (.scratch/lfm25-8b-a1b-support/issues/02-run-conversion-and-upload.md): HITL, pending — requires GPU + HF_TOKEN; conversion + upload run is Pau's to execute on an H100"
+      - "Issue 03 (.scratch/lfm25-8b-a1b-support/issues/03-parser-think-prefix-tolerance.md): added three tests in src-tauri/src/inference/tool_call_parser.rs pinning <think>-prefix tolerance. Existing parser already passes Cases 1+2 (suffix-anchored scan for <|tool_call_start|>); Case 3 reframed during issue review to use two separate <|tool_call_start|>...<|tool_call_end|> blocks since the parser has never supported multi-tool inside one block. Zero production code changes."
+      - "Issue 04 (.scratch/lfm25-8b-a1b-support/issues/04-model-config-and-start-script.md): added lfm25-8b-a1b entry to _models/config.yaml, flipped active_model, reordered fallback_chain. Rewrote scripts/start-model.sh with a --model <key> flag that reads active_model from the YAML via a python one-liner (no YAML dependency added) and looks up filename/port/ctx/HF-repo per key via a case statement."
+      - "Issue 05 (.scratch/lfm25-8b-a1b-support/issues/05-docs-and-progress-update.md): updated CLAUDE.md Project Overview line, swapped README opening narrative + Quick Start to LFM2.5-8B-A1B (with LFM2-24B-A2B preserved as higher-VRAM alternative), added a Known Limitations bullet noting the 8B benchmark gap, created docs/model-analysis/lfm2.5-8b-a1b.md stub with Architecture/Provenance/Quantizations/Inference Params/Known Gaps sections."
+    artifacts_created:
+      - "scripts/convert-8b-a1b.sh (NEW, ~310 lines)"
+      - "docs/model-analysis/lfm2.5-8b-a1b.md (NEW stub)"
+    deferred_in_scope:
+      - "Benchmark run on the curated 20-tool surface against LFM2.5-8B-A1B (single-step accuracy, multi-step chain completion, VRAM/latency on M-series). Risk: shipping a new default without a measured baseline. Mitigation: in-script smoke validation at conversion time gates catastrophic GRPO behavior degradation. Tracked as TODOs in the model-analysis stub."
+      - "UI handling of <think> blocks (collapsed reasoning panel, message-store schema)."
+      - "Long-context wiring (context budget allocation, eviction strategy, --ctx-size bump) leveraging rope5M/longctx_v4 in the source checkpoint."
+      - "ADR-008 successor for reasoning-model temperature handling (no tool_temperature on the new entry)."
+      - "ADR-009 successor for orchestrator pairing with a reasoning planner (orchestrator stays enabled: false)."
+      - "min_p and repetition_penalty schema fields + inference-client plumbing (vendor-recommended but require schema work)."
+    doc_sync: "✓ CLAUDE.md Project Overview, ✓ README.md opening + Quick Start + Known Limitations, ✓ model-analysis stub (new), ✗ docs/PRD.md deliberately not updated per parent PRD out-of-scope list, ✗ no ADR added per issue 05 acceptance criteria"
+    next_recommended: "Branch is non-mergeable to main until LiquidAI publishes the public GGUF repo at LiquidAI/LFM2.5-8B-A1B-GGUF. Once published, the cutover diff is the repo string in _models/config.yaml + scripts/start-model.sh + scripts/convert-8b-a1b.sh + README.md and the model-analysis stub note. Before then: Pau to execute issue 02 (run conversion script on GPU, validate, upload to Paulescu/LFM2.5-8B-A1B-GGUF) and record the llama.cpp commit hash used in the model-analysis stub."
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # BLOCKERS

--- a/examples/localcowork/README.md
+++ b/examples/localcowork/README.md
@@ -4,7 +4,7 @@
 
 **Tool-calling that actually feels instant on a laptop.**
 
-Building a local AI agent sounds great until you try to use one all day. The hard part isn't getting a model to understand you -- it's getting it to choose the right tool and do it fast enough that the experience feels interactive. This is where [LFM2-24B-A2B](https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF) shines: it's designed for tool dispatch on consumer hardware, where latency and memory aren't abstract constraints -- they decide whether your agent is a product or a demo.
+Building a local AI agent sounds great until you try to use one all day. The hard part isn't getting a model to understand you -- it's getting it to choose the right tool and do it fast enough that the experience feels interactive. This is where [LFM2.5-8B-A1B](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF) shines: an 8B sparse-MoE model with 1B active parameters, GRPO-trained for reasoning and tool use, fitting comfortably on a 16 GB laptop. Its predecessor [LFM2-24B-A2B](https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF) remains available as a higher-VRAM alternative.
 
 LocalCowork is a desktop AI agent that runs entirely on-device. No cloud APIs, no data leaving your machine. The model calls pre-built tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP), and every tool execution is logged to a local audit trail.
 
@@ -120,13 +120,13 @@ Full study with 8 models, 150+ scenarios, and 12 failure modes: [`docs/model-ana
 git clone <repo-url> && cd localCoWork
 ./scripts/setup-dev.sh
 
-# 2. Download LFM2-24B-A2B (~14 GB)
-#    https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF
+# 2. Download LFM2.5-8B-A1B (~8.5 GB at Q8_0, fits on a 16 GB Mac)
+#    https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF
 pip install huggingface-hub
 python3 -c "
 from huggingface_hub import hf_hub_download
-hf_hub_download('LiquidAI/LFM2-24B-A2B-GGUF',
-                'LFM2-24B-A2B-Q4_K_M.gguf',
+hf_hub_download('LiquidAI/LFM2.5-8B-A1B-GGUF',
+                'LFM2.5-8B-A1B-Q8_0.gguf',
                 local_dir='$HOME/Projects/_models/')
 "
 
@@ -264,6 +264,7 @@ localCoWork/
 - **1-2 step workflows are reliable.** 4+ step chains degrade as conversation history grows -- multi-step completion is 26% across all tools. The curated 20-tool demo set is selected for proven chain participation.
 - **Batch operations process partial results** -- the model may handle 2 items from a set of 10. Iteration prompting is a known gap.
 - **Cross-server transitions are the universal barrier.** Every model tested fails at these. UX is designed around human confirmation to compensate.
+- **LFM2.5-8B-A1B is the new default; benchmarks above reflect its predecessor LFM2-24B-A2B.** A curated-tool-surface benchmark run on the 8B is pending. The 24B remains selectable via `_models/config.yaml` for users wanting the measured baseline.
 
 These limits are documented because they're instructive. See the [failure taxonomy](docs/model-analysis/) for all 12 failure modes with evidence.
 

--- a/examples/localcowork/README.md
+++ b/examples/localcowork/README.md
@@ -120,13 +120,15 @@ Full study with 8 models, 150+ scenarios, and 12 failure modes: [`docs/model-ana
 git clone <repo-url> && cd localCoWork
 ./scripts/setup-dev.sh
 
-# 2. Download LFM2.5-8B-A1B (~8.5 GB at Q8_0, fits on a 16 GB Mac)
-#    https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF
+# 2. Download LFM2.5-8B-A1B (~5.2 GB at Q4_K_M, fits comfortably on a 16 GB Mac)
+#    Until the official LiquidAI release, use the staging repo:
+#    https://huggingface.co/Paulescu/LFM2.5-8B-A1B-GGUF
+#    (will move to LiquidAI/LFM2.5-8B-A1B-GGUF at release cutover)
 pip install huggingface-hub
 python3 -c "
 from huggingface_hub import hf_hub_download
-hf_hub_download('LiquidAI/LFM2.5-8B-A1B-GGUF',
-                'LFM2.5-8B-A1B-Q8_0.gguf',
+hf_hub_download('Paulescu/LFM2.5-8B-A1B-GGUF',
+                'LFM2.5-8B-A1B-Q4_K_M.gguf',
                 local_dir='$HOME/Projects/_models/')
 "
 

--- a/examples/localcowork/_models/config.yaml
+++ b/examples/localcowork/_models/config.yaml
@@ -108,7 +108,7 @@ models:
   lfm25-8b-a1b:
     display_name: "LFM2.5-8B-A1B-GGUF"
     runtime: llama_cpp
-    model_path: "${LOCALCOWORK_MODELS_DIR:-~/Projects/_models}/LFM2.5-8B-A1B-Q8_0.gguf"
+    model_path: "${LOCALCOWORK_MODELS_DIR:-~/Projects/_models}/LFM2.5-8B-A1B-Q4_K_M.gguf"
     base_url: "http://localhost:8080/v1"
     # TODO: source checkpoint is long-context-trained (rope5M, longctx_v4). Long-context wiring
     # (context budget allocation, eviction strategy, llama-server --ctx-size bump) is deferred.
@@ -118,7 +118,7 @@ models:
     # NOTE: no tool_temperature field; reasoning models emit reasoning + tool-call tokens in one
     # generation, so ADR-008's per-turn dual-temperature pattern doesn't apply. Successor ADR deferred.
     max_tokens: 8192  # Higher than default 4096 so <think> tokens + tool call don't truncate mid-bracket
-    estimated_vram_gb: 10  # Q8_0 weights ~8.5 GB + KV cache + overhead at 32k ctx
+    estimated_vram_gb: 7  # Q4_K_M weights ~5.2 GB + KV cache + overhead at 32k ctx
     capabilities:
       - text
       - tool_calling

--- a/examples/localcowork/_models/config.yaml
+++ b/examples/localcowork/_models/config.yaml
@@ -10,7 +10,7 @@
 #   Model paths below use ${LOCALCOWORK_MODELS_DIR} for interpolation.
 #   The config-loader resolves environment variables at load time.
 
-active_model: lfm2-24b-a2b  # Sparse MoE: 24B total, 2.3B active, 64 experts top-4 — 80% tool accuracy
+active_model: lfm25-8b-a1b  # Sparse MoE: 8B total, 1B active, GRPO-trained reasoning + tool use, ~10 GB VRAM at Q8_0
 
 # Default model directory for non-Ollama model files (GGUF, MLX, etc.)
 models_dir: "${LOCALCOWORK_MODELS_DIR:-~/Projects/_models}"
@@ -96,6 +96,29 @@ models:
     temperature: 0.7
     max_tokens: 4096
     estimated_vram_gb: 14
+    capabilities:
+      - text
+      - tool_calling
+
+  # LFM2.5-8B-A1B: Sparse MoE reasoning model (default for LocalCowork as of 2026-05-21)
+  # Architecture: 8B total, 1B active per token, GRPO-trained for reasoning + tool use.
+  # Emits <think>...</think> reasoning blocks before bracket-format tool calls.
+  # Dev artifacts (private): https://huggingface.co/Paulescu/LFM2.5-8B-A1B-GGUF
+  # TODO: switch model_path repo to LiquidAI/LFM2.5-8B-A1B-GGUF at release cutover.
+  lfm25-8b-a1b:
+    display_name: "LFM2.5-8B-A1B-GGUF"
+    runtime: llama_cpp
+    model_path: "${LOCALCOWORK_MODELS_DIR:-~/Projects/_models}/LFM2.5-8B-A1B-Q8_0.gguf"
+    base_url: "http://localhost:8080/v1"
+    # TODO: source checkpoint is long-context-trained (rope5M, longctx_v4). Long-context wiring
+    # (context budget allocation, eviction strategy, llama-server --ctx-size bump) is deferred.
+    context_window: 32768
+    tool_call_format: bracket  # GRPO-trained: <think>...</think> + <|tool_call_start|>[server.tool(args)]<|tool_call_end|>
+    temperature: 0.3  # Per public LFM2-8B-A1B model card recommendation
+    # NOTE: no tool_temperature field; reasoning models emit reasoning + tool-call tokens in one
+    # generation, so ADR-008's per-turn dual-temperature pattern doesn't apply. Successor ADR deferred.
+    max_tokens: 8192  # Higher than default 4096 so <think> tokens + tool call don't truncate mid-bracket
+    estimated_vram_gb: 10  # Q8_0 weights ~8.5 GB + KV cache + overhead at 32k ctx
     capabilities:
       - text
       - tool_calling
@@ -380,9 +403,10 @@ runtimes:
 
 # Fallback chain — used when the active model is unavailable
 fallback_chain:
-  - lfm2-24b-a2b     # Primary — 78% single-step, 24% chain completion
-  - qwen3-30b-moe    # Fallback 1 — Ollama-hosted Qwen3 MoE
-  - static_response   # Fallback 2 — hardcoded "model unavailable" message
+  - lfm25-8b-a1b     # Primary — GRPO reasoning + tool calling, ~10 GB VRAM at Q8_0
+  - lfm2-24b-a2b     # Fallback 1 — proven 78% single-step, 24% chain completion
+  - qwen3-30b-moe    # Fallback 2 — Ollama-hosted Qwen3 MoE
+  - static_response   # Fallback 3 — hardcoded "model unavailable" message
 
 # Dual-model orchestrator (ADR-009)
 # When enabled, the planner model decomposes multi-step workflows and

--- a/examples/localcowork/docs/model-analysis/lfm2.5-8b-a1b.md
+++ b/examples/localcowork/docs/model-analysis/lfm2.5-8b-a1b.md
@@ -1,0 +1,76 @@
+# LFM2.5-8B-A1B Model Analysis (Stub)
+
+**Last updated**: 2026-05-21
+**Status**: New default model for LocalCowork. Benchmark run on the curated tool surface pending.
+**Config**: `_models/config.yaml` entry `lfm25-8b-a1b`
+
+This is a stub. Sections below capture what is currently known and mark unknowns with explicit `TODO:` lines. As benchmarks land, this file should grow toward the depth of `lfm2-24b-a2b-benchmark.md` and `gpt-oss-20b.md`.
+
+---
+
+## Architecture
+
+| Property | Value |
+|----------|-------|
+| Total parameters | 8B |
+| Active parameters per token | 1B (A1B) |
+| Architecture | Mixture-of-Experts, LFM2.5 hybrid attention + conv |
+| Training objective | GRPO (reasoning + tool use) |
+| Predecessor | Publicly released LFM2-8B-A1B |
+| Tool-call format | `bracket` with `<think>...</think>` reasoning prefix |
+| Reasoning output | Current turn's `<think>` block flows into chat content as-is; prior turns' thinking is stripped by the chat template (`preserve_thinking` defaults false) |
+
+LFM2.5-8B-A1B is the successor to the publicly released LFM2-8B-A1B. The 8B / 1B-active split is the same; LFM2.5 adds long-context training and GRPO reasoning to the recipe.
+
+---
+
+## Provenance
+
+- **Source checkpoint**: `LiquidAI/fernando_grpo_8B_MoE_from06081_longctx_v4_rope5M_step90_762484_HF` (private)
+- **Training run signal**: the source checkpoint name embeds `longctx_v4` and `rope5M`, indicating long-context training with RoPE base scaling. **Long-context wiring (context budget allocation, eviction strategy, `start-model.sh --ctx-size` bump) is deferred to a follow-up PR.** The conservative 32k `context_window` in `_models/config.yaml` reflects this deferral, not a model limit.
+- **GRPO step**: step 90 (`step90_762484_HF` suffix). Behavioral consequence: the model emits `<think>...</think>` reasoning blocks before bracket-format tool calls. The bracket parser tolerates this prefix (see `bracket_tolerates_think_prefix_*` tests in `src-tauri/src/inference/tool_call_parser.rs`).
+
+---
+
+## Quantizations Published
+
+| Quant | Approx. size | Purpose |
+|-------|--------------|---------|
+| F16 | ~16 GB | Conversion intermediate, not uploaded |
+| Q8_0 | ~8.5 GB | Production default (cookbook target: 16 GB Mac) |
+| Q4_K_M | ~5 GB | Lightweight option for tighter VRAM budgets |
+
+- **Dev mirror (private, pre-release)**: [`Paulescu/LFM2.5-8B-A1B-GGUF`](https://huggingface.co/Paulescu/LFM2.5-8B-A1B-GGUF)
+- **Public release target**: `LiquidAI/LFM2.5-8B-A1B-GGUF`. The cookbook branch `localcowork-lfm2.5-8b-a1b` is non-mergeable to `main` until this public repo exists; the cutover diff is the repo string in `_models/config.yaml` and `README.md`.
+- **F16 is intentionally not uploaded.** It is a conversion artifact only; only Q4_K_M and Q8_0 are pushed.
+
+`TODO`: record the `llama.cpp` commit hash used for the conversion run (filled in by issue 02 operator after the first successful run of `scripts/convert-8b-a1b.sh`).
+
+---
+
+## Recommended Inference Params
+
+| Param | Value | Source |
+|-------|-------|--------|
+| `temperature` | `0.3` | Public LFM2-8B-A1B model card on Hugging Face |
+| `max_tokens` | `8192` | Reasoning models routinely emit 200-800 thinking tokens before the tool call on simple prompts and significantly more on harder ones; the previous 4096 default risks mid-bracket truncation |
+| `context_window` | `32768` | Stack convention; long-context capability deferred |
+| `tool_temperature` | (unset) | Reasoning models emit reasoning + tool-call tokens within a single generation, so the per-turn dual-temperature pattern from ADR-008 doesn't apply. Successor ADR is deferred |
+
+**Deliberately deferred** (vendor-recommended but require schema and inference-client plumbing):
+
+- `min_p: 0.15`: vendor-recommended in the LFM2-8B-A1B model card.
+- `repetition_penalty: 1.05`: vendor-recommended in the LFM2-8B-A1B model card.
+
+Adding these requires extending the model config schema and threading the values through the Rust inference client; scoped out of the current PR to keep its surface area minimal. See the parent PRD's "Deferred to follow-up issues" list.
+
+---
+
+## Known Gaps
+
+- `TODO`: single-step tool-call accuracy on the curated 20-tool surface.
+- `TODO`: multi-step chain-completion rate vs LFM2-24B-A2B baseline.
+- `TODO`: VRAM and latency measurements on M-series Macs (M1, M2, M3, M4) at Q8_0 and Q4_K_M.
+- `TODO`: behavior comparison with vs without `<think>` blocks suppressed at decode time (does the model still emit reliable tool calls, and at what accuracy cost, if reasoning is turned off?).
+
+These are explicit gaps, not omissions. The PRD author accepted the risk of shipping a new default model without a benchmark run on the curated tool surface, mitigated by the in-script smoke validation at conversion time (see `scripts/convert-8b-a1b.sh`).

--- a/examples/localcowork/scripts/convert-8b-a1b.sh
+++ b/examples/localcowork/scripts/convert-8b-a1b.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# LocalCowork: Convert LFM2.5-8B-A1B safetensors checkpoint to GGUF
+#
+# Purpose (one-shot, run-on-demand, NOT invoked by CI):
+#   1. Convert the safetensors checkpoint at <hf-model-dir> to F16 GGUF.
+#   2. Quantize F16 → Q8_0 and F16 → Q4_K_M.
+#   3. Spawn a temporary llama-server against Q8_0 and validate that a
+#      tool-calling prompt produces a <think>...</think> block AND a
+#      parseable <|tool_call_start|>[...]<|tool_call_end|> call.
+#   4. Optionally upload Q4_K_M and Q8_0 (NOT F16) to the dev HF repo.
+#
+# Usage:
+#   ./scripts/convert-8b-a1b.sh <hf-model-dir>            # convert + validate
+#   ./scripts/convert-8b-a1b.sh <hf-model-dir> --upload   # also push to HF
+#
+# Required environment:
+#   HF_TOKEN        HuggingFace write token. Picked up automatically by
+#                   huggingface-hub / huggingface-cli; no custom auth in
+#                   this script. Only required when --upload is set.
+#   LLAMA_CPP_DIR   Path to local llama.cpp checkout containing
+#                   convert_hf_to_gguf.py, llama-quantize, and llama-server.
+#                   Defaults to $HOME/llama.cpp.
+#
+# llama.cpp version requirement:
+#   LFM2.5-8B-A1B requires mainline llama.cpp support for the LFM2.5 MoE
+#   (A1B) architecture. The first dry-run of this script verifies arch
+#   support: convert_hf_to_gguf.py will exit non-zero on unsupported arch.
+#   The actual commit hash used is printed in the run banner and is meant
+#   to be copy-pasted into docs/model-analysis/lfm2.5-8b-a1b.md after a
+#   successful run.
+#
+# Source / target HF repos:
+#   Source (private):  LiquidAI/fernando_grpo_8B_MoE_from06081_longctx_v4_rope5M_step90_762484_HF
+#   Dev target:        Paulescu/LFM2.5-8B-A1B-GGUF        (this script)
+#   Release target:    LiquidAI/LFM2.5-8B-A1B-GGUF        (edit DEV_HF_REPO below at release cutover)
+#
+# Design note: this is a deliberate copy-and-edit of scripts/convert-to-gguf.sh.
+# It runs twice in its lifetime (once now to the dev repo, once at release to
+# the public repo). Abstracting into a shared library is overhead with no payback.
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# ── Constants (hand-edit at release cutover) ────────────────────────────────
+
+MODEL_BASENAME="LFM2.5-8B-A1B"
+DEV_HF_REPO="Paulescu/${MODEL_BASENAME}-GGUF"
+# At release cutover, change DEV_HF_REPO to "LiquidAI/${MODEL_BASENAME}-GGUF".
+
+F16_NAME="${MODEL_BASENAME}-F16.gguf"
+Q8_NAME="${MODEL_BASENAME}-Q8_0.gguf"
+Q4_NAME="${MODEL_BASENAME}-Q4_K_M.gguf"
+
+VALIDATION_PORT=8099
+VALIDATION_TEMPERATURE=0.3
+VALIDATION_CTX_SIZE=8192
+VALIDATION_MAX_TOKENS=4096
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+UPLOAD=false
+MODEL_DIR=""
+
+print_usage() {
+    sed -n '2,/^# ────/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --upload) UPLOAD=true ;;
+        --help|-h) print_usage; exit 0 ;;
+        -*) echo "Unknown flag: $arg" >&2; exit 1 ;;
+        *)
+            if [ -z "$MODEL_DIR" ]; then
+                MODEL_DIR="$arg"
+            else
+                echo "Unexpected positional arg: $arg" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$MODEL_DIR" ]; then
+    echo "Usage: $0 <hf-model-dir> [--upload]" >&2
+    exit 1
+fi
+if [ ! -d "$MODEL_DIR" ]; then
+    echo "Model dir not found: $MODEL_DIR" >&2
+    exit 1
+fi
+if [ "$UPLOAD" = true ] && [ -z "${HF_TOKEN:-}" ]; then
+    echo "✗ --upload requires HF_TOKEN env var (picked up by huggingface-cli)" >&2
+    exit 1
+fi
+
+LLAMA_CPP="${LLAMA_CPP_DIR:-$HOME/llama.cpp}"
+OUTPUT_DIR="${OUTPUT_DIR:-$(dirname "$MODEL_DIR")/gguf}"
+mkdir -p "$OUTPUT_DIR"
+
+F16_PATH="$OUTPUT_DIR/$F16_NAME"
+Q8_PATH="$OUTPUT_DIR/$Q8_NAME"
+Q4_PATH="$OUTPUT_DIR/$Q4_NAME"
+SERVER_LOG="$OUTPUT_DIR/.validate-server.log"
+
+LLAMA_CPP_COMMIT=$(git -C "$LLAMA_CPP" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+echo "=== LFM2.5-8B-A1B GGUF Conversion ==="
+echo "  Model dir:    $MODEL_DIR"
+echo "  llama.cpp:    $LLAMA_CPP (commit $LLAMA_CPP_COMMIT)"
+echo "  Output dir:   $OUTPUT_DIR"
+if [ "$UPLOAD" = true ]; then
+    echo "  Upload:       yes → $DEV_HF_REPO (Q4_K_M, Q8_0 only)"
+else
+    echo "  Upload:       no (pass --upload to push)"
+fi
+echo
+
+# ── Step 1: HF safetensors → F16 GGUF ────────────────────────────────────────
+
+echo "[1/5] Converting HF safetensors → GGUF (F16)..."
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" \
+    "$MODEL_DIR" \
+    --outfile "$F16_PATH" \
+    --outtype f16
+
+echo "  → $F16_PATH ($(du -h "$F16_PATH" | cut -f1))"
+echo
+
+# ── Step 2: F16 → Q8_0 ───────────────────────────────────────────────────────
+
+echo "[2/5] Quantizing → Q8_0..."
+"$LLAMA_CPP/llama-quantize" "$F16_PATH" "$Q8_PATH" Q8_0
+echo "  → $Q8_PATH ($(du -h "$Q8_PATH" | cut -f1))"
+echo
+
+# ── Step 3: F16 → Q4_K_M ─────────────────────────────────────────────────────
+
+echo "[3/5] Quantizing → Q4_K_M..."
+"$LLAMA_CPP/llama-quantize" "$F16_PATH" "$Q4_PATH" Q4_K_M
+echo "  → $Q4_PATH ($(du -h "$Q4_PATH" | cut -f1))"
+echo
+
+# ── Step 4: Spawn llama-server and validate tool-calling behavior ───────────
+
+echo "[4/5] Validating Q8_0 with llama-server (port $VALIDATION_PORT)..."
+
+"$LLAMA_CPP/llama-server" \
+    --model "$Q8_PATH" \
+    --port "$VALIDATION_PORT" \
+    --ctx-size "$VALIDATION_CTX_SIZE" \
+    --n-gpu-layers 99 \
+    --jinja \
+    > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup_server() {
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_server EXIT
+
+echo -n "  Waiting for server"
+for i in $(seq 1 60); do
+    if curl -sf "http://localhost:$VALIDATION_PORT/health" > /dev/null 2>&1; then
+        echo " ready"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo " timeout after 60s" >&2
+        echo "  Server log: $SERVER_LOG" >&2
+        exit 1
+    fi
+    sleep 1
+    echo -n "."
+done
+
+REQUEST_BODY=$(cat <<JSON
+{
+  "messages": [
+    {"role": "system", "content": "You are a tool-using assistant. Think step by step inside <think>...</think>, then call exactly one tool."},
+    {"role": "user", "content": "List the files in my Downloads folder."}
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "filesystem.list_dir",
+        "description": "List entries in a directory.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {"type": "string", "description": "Absolute path of the directory to list."}
+          },
+          "required": ["path"]
+        }
+      }
+    }
+  ],
+  "temperature": $VALIDATION_TEMPERATURE,
+  "max_tokens": $VALIDATION_MAX_TOKENS
+}
+JSON
+)
+
+RESPONSE=$(curl -sS "http://localhost:$VALIDATION_PORT/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "$REQUEST_BODY")
+
+if [ -z "$RESPONSE" ]; then
+    echo "✗ Empty response from llama-server" >&2
+    echo "  Server log: $SERVER_LOG" >&2
+    exit 1
+fi
+
+# Validate response: must contain a <think>...</think> block AND a parseable
+# bracket-format tool call. llama.cpp may extract either into structured
+# fields (reasoning_content, tool_calls) depending on version and --jinja
+# behavior; accept either the literal markers OR the structured equivalents.
+VALIDATION_EXIT=0
+VALIDATION_OUTPUT=$(RESPONSE_JSON="$RESPONSE" python3 -c '
+import json
+import os
+import sys
+
+raw = os.environ.get("RESPONSE_JSON", "")
+try:
+    data = json.loads(raw)
+    msg = data["choices"][0]["message"]
+except (KeyError, IndexError, json.JSONDecodeError) as e:
+    print(f"PARSE_ERROR: {e}", file=sys.stderr)
+    print(raw[:4000], file=sys.stderr)
+    sys.exit(2)
+
+content = msg.get("content") or ""
+reasoning = msg.get("reasoning_content") or ""
+tool_calls = msg.get("tool_calls") or []
+
+has_think_literal = "<think>" in content and "</think>" in content
+has_think_extracted = bool(reasoning.strip())
+has_think = has_think_literal or has_think_extracted
+
+has_bracket_literal = "<|tool_call_start|>" in content and "<|tool_call_end|>" in content
+has_tool_calls_extracted = len(tool_calls) > 0
+has_tool_call = has_bracket_literal or has_tool_calls_extracted
+
+print("--- content ---")
+print(content[:2000])
+print("--- reasoning_content ---")
+print(reasoning[:2000])
+print("--- tool_calls ---")
+print(json.dumps(tool_calls, indent=2)[:2000])
+print("--- checks ---")
+print(f"has_think:     {has_think}  (literal={has_think_literal}, extracted={has_think_extracted})")
+print(f"has_tool_call: {has_tool_call}  (literal={has_bracket_literal}, extracted={has_tool_calls_extracted})")
+
+if not has_think:
+    sys.exit(3)
+if not has_tool_call:
+    sys.exit(4)
+sys.exit(0)
+') || VALIDATION_EXIT=$?
+
+echo "$VALIDATION_OUTPUT" | sed 's/^/  | /'
+
+case "$VALIDATION_EXIT" in
+    0) echo "  ✓ Validation passed (<think> block + bracket tool call present)" ;;
+    2) echo "✗ Could not parse llama-server response as JSON" >&2; exit 1 ;;
+    3) echo "✗ Validation failed: response lacks <think>...</think> block" >&2; exit 1 ;;
+    4) echo "✗ Validation failed: response lacks bracket-format tool-call markers" >&2; exit 1 ;;
+    *) echo "✗ Validation failed (exit $VALIDATION_EXIT)" >&2; exit 1 ;;
+esac
+
+cleanup_server
+trap - EXIT
+echo
+
+# ── Step 5: Upload (only if --upload) ───────────────────────────────────────
+
+if [ "$UPLOAD" = true ]; then
+    echo "[5/5] Uploading Q4_K_M and Q8_0 to $DEV_HF_REPO..."
+    echo "      (F16 intermediate is deliberately NOT uploaded.)"
+    echo
+
+    huggingface-cli upload "$DEV_HF_REPO" "$Q8_PATH" "$Q8_NAME"
+    huggingface-cli upload "$DEV_HF_REPO" "$Q4_PATH" "$Q4_NAME"
+
+    echo
+    echo "  ✓ Uploaded:"
+    echo "    - $Q8_NAME"
+    echo "    - $Q4_NAME"
+else
+    echo "[5/5] Skipping upload (no --upload flag)"
+fi
+
+echo
+echo "=== Done ==="
+echo "  llama.cpp commit: $LLAMA_CPP_COMMIT"
+echo "  Local files:"
+ls -lh "$OUTPUT_DIR/${MODEL_BASENAME}"-*.gguf
+if [ "$UPLOAD" = true ]; then
+    echo
+    echo "  HF repo:          https://huggingface.co/$DEV_HF_REPO"
+    echo "  Record the llama.cpp commit ($LLAMA_CPP_COMMIT) in"
+    echo "  docs/model-analysis/lfm2.5-8b-a1b.md per issue 05."
+fi

--- a/examples/localcowork/scripts/start-model.sh
+++ b/examples/localcowork/scripts/start-model.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # ─────────────────────────────────────────────────────────────────────────────
-# LocalCowork — Start Model Server
+# LocalCowork: Start Model Server
 #
-# Starts llama-server for the active model defined in _models/config.yaml.
+# Starts llama-server for a model defined in _models/config.yaml.
 # Usage:
-#   ./scripts/start-model.sh              # Start LFM2-24B-A2B (default)
-#   ./scripts/start-model.sh --vision     # Also start vision model on port 8081
-#   ./scripts/start-model.sh --check      # Just check if models are downloaded
+#   ./scripts/start-model.sh                          # Start the active_model from the config
+#   ./scripts/start-model.sh --model lfm25-8b-a1b     # Start a specific model
+#   ./scripts/start-model.sh --model lfm2-24b-a2b     # Start the predecessor
+#   ./scripts/start-model.sh --vision                 # Also start vision model on port 8081
+#   ./scripts/start-model.sh --check                  # Just check if model files are downloaded
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -14,42 +16,118 @@ set -euo pipefail
 
 MODELS_DIR="${LOCALCOWORK_MODELS_DIR:-$HOME/Projects/_models}"
 
-# Main model (LFM2-24B-A2B)
-MAIN_MODEL="LFM2-24B-A2B-Q4_K_M.gguf"
-MAIN_PORT=8080
-MAIN_CTX=32768
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_FILE="$PROJECT_ROOT/_models/config.yaml"
 
-# Vision model (LFM2.5-VL-1.6B)
+# Vision model (LFM2.5-VL-1.6B): always on port 8081, independent of --model
 VISION_MODEL="LFM2.5-VL-1.6B-Q8_0.gguf"
 VISION_MMPROJ="mmproj-LFM2.5-VL-1.6b-Q8_0.gguf"
 VISION_PORT=8081
+
+# Read the active_model key from _models/config.yaml.
+# Small Python one-liner per issue scope: no YAML-parsing dependency added,
+# just regex on the top-level key.
+read_active_model() {
+    python3 -c '
+import re, sys
+with open(sys.argv[1]) as f:
+    for line in f:
+        m = re.match(r"^active_model:\s*(\S+)", line)
+        if m:
+            print(m.group(1)); sys.exit(0)
+sys.exit(1)
+' "$CONFIG_FILE"
+}
+
+# Map a model key from _models/config.yaml to the bits start-model.sh needs:
+# the on-disk filename, the llama-server port, the context size, the HF repo
+# for download instructions, and the human-readable display name.
+#
+# Sets MAIN_MODEL, MAIN_PORT, MAIN_CTX, MAIN_DOWNLOAD_REPO, MAIN_DISPLAY.
+# Exits 1 for unknown or ollama-runtime keys.
+resolve_model() {
+    case "$1" in
+        lfm25-8b-a1b)
+            MAIN_MODEL="LFM2.5-8B-A1B-Q8_0.gguf"
+            MAIN_PORT=8080
+            MAIN_CTX=32768
+            # TODO: switch to LiquidAI/LFM2.5-8B-A1B-GGUF at release cutover.
+            MAIN_DOWNLOAD_REPO="Paulescu/LFM2.5-8B-A1B-GGUF"
+            MAIN_DISPLAY="LFM2.5-8B-A1B"
+            ;;
+        lfm2-24b-a2b)
+            MAIN_MODEL="LFM2-24B-A2B-Q4_K_M.gguf"
+            MAIN_PORT=8080
+            MAIN_CTX=32768
+            MAIN_DOWNLOAD_REPO="LiquidAI/LFM2-24B-A2B-GGUF"
+            MAIN_DISPLAY="LFM2-24B-A2B"
+            ;;
+        *)
+            echo "❌ Model key '$1' is not supported by start-model.sh." >&2
+            echo "   Supported keys: lfm25-8b-a1b, lfm2-24b-a2b" >&2
+            echo "   (Ollama-hosted models like gpt-oss-20b start via 'ollama serve'.)" >&2
+            exit 1
+            ;;
+    esac
+}
 
 # ── Parse arguments ──────────────────────────────────────────────────────────
 
 START_VISION=false
 CHECK_ONLY=false
+MODEL_KEY=""
 
-for arg in "$@"; do
-    case "$arg" in
-        --vision)  START_VISION=true ;;
-        --check)   CHECK_ONLY=true ;;
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --vision) START_VISION=true; shift ;;
+        --check)  CHECK_ONLY=true; shift ;;
+        --model)
+            if [ $# -lt 2 ]; then
+                echo "--model requires a key argument (e.g. --model lfm25-8b-a1b)" >&2
+                exit 1
+            fi
+            MODEL_KEY="$2"
+            shift 2
+            ;;
         --help|-h)
-            echo "Usage: $0 [--vision] [--check]"
-            echo ""
-            echo "  --vision    Also start the vision model server (port $VISION_PORT)"
-            echo "  --check     Check if model files exist (don't start servers)"
-            echo ""
-            echo "Environment:"
-            echo "  LOCALCOWORK_MODELS_DIR    Model directory (default: ~/Projects/_models)"
+            cat <<HELP
+Usage: $0 [--model <key>] [--vision] [--check]
+
+  --model <key>   Start the model identified by <key> in _models/config.yaml.
+                  Defaults to the active_model from the config.
+                  Supported keys (handled by this script): lfm25-8b-a1b, lfm2-24b-a2b.
+  --vision        Also start the vision model server on port $VISION_PORT.
+  --check         Check if model files exist (don't start servers).
+
+Environment:
+  LOCALCOWORK_MODELS_DIR    Model directory (default: ~/Projects/_models)
+HELP
             exit 0
             ;;
         *)
-            echo "Unknown argument: $arg"
-            echo "Run '$0 --help' for usage."
+            echo "Unknown argument: $1" >&2
+            echo "Run '$0 --help' for usage." >&2
             exit 1
             ;;
     esac
 done
+
+# ── Resolve model selection ──────────────────────────────────────────────────
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "❌ Config not found: $CONFIG_FILE" >&2
+    exit 1
+fi
+
+if [ -z "$MODEL_KEY" ]; then
+    if ! MODEL_KEY=$(read_active_model); then
+        echo "❌ Could not read active_model from $CONFIG_FILE" >&2
+        exit 1
+    fi
+fi
+
+resolve_model "$MODEL_KEY"
 
 # ── Check llama-server ───────────────────────────────────────────────────────
 
@@ -72,6 +150,7 @@ echo "✅ llama-server found: $(command -v llama-server)"
 
 echo ""
 echo "Models directory: $MODELS_DIR"
+echo "Selected model:   $MODEL_KEY ($MAIN_DISPLAY)"
 echo ""
 
 MAIN_PATH="$MODELS_DIR/$MAIN_MODEL"
@@ -84,14 +163,14 @@ if [ -f "$MAIN_PATH" ]; then
 else
     echo "❌ Main model not found: $MAIN_PATH"
     echo ""
-    echo "   Download LFM2-24B-A2B from HuggingFace:"
-    echo "   https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF"
+    echo "   Download $MAIN_DISPLAY from HuggingFace:"
+    echo "   https://huggingface.co/$MAIN_DOWNLOAD_REPO"
     echo ""
     echo "   pip install huggingface-hub"
     echo "   python3 -c \""
     echo "     from huggingface_hub import hf_hub_download"
-    echo "     hf_hub_download('LiquidAI/LFM2-24B-A2B-GGUF',"
-    echo "                     'LFM2-24B-A2B-Q4_K_M.gguf',"
+    echo "     hf_hub_download('$MAIN_DOWNLOAD_REPO',"
+    echo "                     '$MAIN_MODEL',"
     echo "                     local_dir='$MODELS_DIR')"
     echo "   \""
     if [ "$CHECK_ONLY" = true ]; then
@@ -104,7 +183,7 @@ fi
 if [ -f "$VISION_PATH" ] && [ -f "$MMPROJ_PATH" ]; then
     echo "✅ Vision model:  $VISION_MODEL + mmproj"
 else
-    echo "⚠️  Vision model not found (optional — OCR falls back to Tesseract)"
+    echo "⚠️  Vision model not found (optional; OCR falls back to Tesseract)"
     if [ "$START_VISION" = true ]; then
         echo ""
         echo "   Download from: https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF"
@@ -126,13 +205,13 @@ fi
 # ── Start main model server ─────────────────────────────────────────────────
 
 if [ ! -f "$MAIN_PATH" ]; then
-    echo "Cannot start server — main model file missing."
+    echo "Cannot start server; main model file missing."
     exit 1
 fi
 
 echo ""
 echo "═══════════════════════════════════════════════════"
-echo "  Starting LFM2-24B-A2B on port $MAIN_PORT"
+echo "  Starting $MAIN_DISPLAY on port $MAIN_PORT"
 echo "═══════════════════════════════════════════════════"
 echo "  Model:   $MAIN_MODEL"
 echo "  Context: $MAIN_CTX tokens"

--- a/examples/localcowork/scripts/start-model.sh
+++ b/examples/localcowork/scripts/start-model.sh
@@ -49,7 +49,7 @@ sys.exit(1)
 resolve_model() {
     case "$1" in
         lfm25-8b-a1b)
-            MAIN_MODEL="LFM2.5-8B-A1B-Q8_0.gguf"
+            MAIN_MODEL="LFM2.5-8B-A1B-Q4_K_M.gguf"
             MAIN_PORT=8080
             MAIN_CTX=32768
             # TODO: switch to LiquidAI/LFM2.5-8B-A1B-GGUF at release cutover.
@@ -224,7 +224,7 @@ llama-server \
     --port "$MAIN_PORT" \
     --ctx-size "$MAIN_CTX" \
     --n-gpu-layers 99 \
-    --flash-attn &
+    --flash-attn on &
 
 MAIN_PID=$!
 echo "  PID: $MAIN_PID"

--- a/examples/localcowork/src-tauri/src/inference/tool_call_parser.rs
+++ b/examples/localcowork/src-tauri/src/inference/tool_call_parser.rs
@@ -1074,4 +1074,46 @@ Arguments: {\"path\": \"/tmp/test.txt\"}";
             Some("Review Q4")
         );
     }
+
+    // ─── Reasoning-prefix tolerance (LFM2.5-8B-A1B) ─────────────────────────
+    //
+    // Pins external behavior: a leading <think>...</think> reasoning block
+    // before a bracket-format tool call must not prevent the call from being
+    // parsed. Existing behavior (no prefix, multi-call) must remain intact.
+
+    #[test]
+    fn bracket_tolerates_think_prefix_single_call() {
+        let text = "<think>some reasoning text</think>\
+                    <|tool_call_start|>[server.tool(arg='val')]<|tool_call_end|>";
+        let calls = parse_bracket_tool_calls(text).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "server.tool");
+        assert_eq!(calls[0].arguments["arg"], "val");
+        assert!(calls[0].id.starts_with("call_"));
+    }
+
+    #[test]
+    fn bracket_without_think_prefix_single_call() {
+        let text = "<|tool_call_start|>[server.tool(arg='val')]<|tool_call_end|>";
+        let calls = parse_bracket_tool_calls(text).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "server.tool");
+        assert_eq!(calls[0].arguments["arg"], "val");
+        assert!(calls[0].id.starts_with("call_"));
+    }
+
+    #[test]
+    fn bracket_tolerates_think_prefix_multi_call() {
+        // Multi-call is emitted as multiple <|tool_call_start|>...<|tool_call_end|>
+        // blocks (one call per block), per the parser's existing contract.
+        let text = "<think>reasoning</think>\
+                    <|tool_call_start|>[s1.t1(a=1)]<|tool_call_end|>\
+                    <|tool_call_start|>[s2.t2(b=2)]<|tool_call_end|>";
+        let calls = parse_bracket_tool_calls(text).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "s1.t1");
+        assert_eq!(calls[0].arguments["a"], 1);
+        assert_eq!(calls[1].name, "s2.t2");
+        assert_eq!(calls[1].arguments["b"], 2);
+    }
 }


### PR DESCRIPTION
## Summary

- Make **LFM2.5-8B-A1B** the default LocalCowork model, replacing the previous gated Preview reference with a public GGUF.
- Ship at **Q4_K_M** (~5.2 GB) instead of Q8_0 (~8.5 GB) so the model fits comfortably on a 16 GB Mac alongside the OS and other apps.
- Add a `start-model.sh` resolver and a `convert-8b-a1b.sh` helper for the conversion workflow.
- Wire a tool-call parser hook for the new model's bracket-format output.
- Point downloads at the `Paulescu/LFM2.5-8B-A1B-GGUF` staging repo until the LiquidAI public release cutover (tracked in TODO comments in `start-model.sh` and `_models/config.yaml`).
- Minor: fix `llama-server --flash-attn` invocation (now requires explicit `on`); add an Agent-skills section to `CLAUDE.md`.

## Test plan

- [ ] `./scripts/start-model.sh lfm25-8b-a1b` boots llama-server on port 8080 with the Q4_K_M weights and a 32k context window.
- [ ] `curl -s http://localhost:8080/v1/models` returns the model id.
- [ ] Smoke a tool-call prompt end-to-end and confirm the bracket-format parser produces a valid tool invocation.
- [ ] Verify the README quick-start download command pulls `LFM2.5-8B-A1B-Q4_K_M.gguf` from the staging repo without auth.
- [ ] Confirm `estimated_vram_gb: 7` is realistic on an M-series Mac at 32k ctx.