### PR TITLE
fix: stabilize telco dialogue routing

### DIFF
--- a/examples/telco-triage-ios/TelcoTriage/Core/Composer/AnswerComposer.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Composer/AnswerComposer.swift
@@ -99,6 +99,7 @@ public struct DeterministicAnswerComposer: AnswerComposing {
                     hasStepChain = true
                 } else {
                     text = renderGroundedSummaryAnswer(
+                        query: query,
                         unit: unit,
                         route: route
                     )
@@ -239,14 +240,20 @@ private func customerFacingTaskPhrase(_ task: String) -> String {
 /// while preserving the hard guarantee that every visible claim is
 /// extracted from the selected `RAGUnit`.
 private func renderGroundedSummaryAnswer(
+    query: String,
     unit: RAGUnit,
     route: ComposerRoute
 ) -> String {
     let label = unit.displayLabel
     let link = renderLink(label: label, url: unit.canonicalURL)
-    let lead = leadSentence(from: unit)
+    let lead = leadSentence(from: unit, query: query)
         ?? "This section covers \(humanizedLabel(label))."
-    let facts = sourceOrderedFactSentences(from: unit, excluding: lead, limit: 4)
+    let facts: [String]
+    if prefersRankedSummary(for: query) {
+        facts = rankedFactSentences(from: unit, query: query, excluding: lead, limit: 4)
+    } else {
+        facts = sourceOrderedFactSentences(from: unit, excluding: lead, limit: 4)
+    }
 
     var sections: [String] = [lead]
     if !facts.isEmpty {
@@ -266,17 +273,40 @@ private func renderGroundedSummaryAnswer(
     return sections.joined(separator: "\n\n")
 }
 
-private func leadSentence(from unit: RAGUnit) -> String? {
+private func leadSentence(from unit: RAGUnit, query: String) -> String? {
     let sentences = sourceSentences(from: unit.body)
-    let titleTokens = Set(BM25Tokenizer.tokenize(unit.title))
-    let labelTokens = Set(BM25Tokenizer.tokenize(unit.displayLabel))
-    let objectiveTokens = titleTokens.union(labelTokens)
+        .filter { !isLowValueSummarySentence($0) }
+    guard !sentences.isEmpty else { return nil }
 
-    for sentence in sentences.prefix(5) {
-        let sentenceTokens = Set(BM25Tokenizer.tokenize(sentence))
-        if !sentenceTokens.intersection(objectiveTokens).isEmpty {
-            return sentence
+    guard prefersRankedSummary(for: query) else {
+        let objectiveTokens = Set(BM25Tokenizer.tokenize(unit.title))
+            .union(BM25Tokenizer.tokenize(unit.displayLabel))
+        for sentence in sentences.prefix(5) {
+            let sentenceTokens = Set(BM25Tokenizer.tokenize(sentence))
+            if !sentenceTokens.intersection(objectiveTokens).isEmpty {
+                return sentence
+            }
         }
+        return sentences.first
+    }
+
+    let queryTokens = summaryFocusTokens(for: query)
+    let objectiveTokens = summaryObjectiveTokens(for: unit)
+    if let match = rankedSentenceMatches(
+        sentences: sentences,
+        queryTokens: queryTokens,
+        objectiveTokens: objectiveTokens,
+        excluding: nil
+    ).first(where: { $0.queryOverlap > 0 }) {
+        return match.sentence
+    }
+    if let match = rankedSentenceMatches(
+        sentences: sentences,
+        queryTokens: queryTokens,
+        objectiveTokens: objectiveTokens,
+        excluding: nil
+    ).first(where: { $0.objectiveOverlap > 0 }) {
+        return match.sentence
     }
     return sentences.first
 }
@@ -287,6 +317,7 @@ private func sourceOrderedFactSentences(
     limit: Int
 ) -> [String] {
     let sentences = sourceSentences(from: unit.body)
+        .filter { !isLowValueSummarySentence($0) }
     guard let leadIndex = sentences.firstIndex(of: lead) else {
         return Array(sentences.filter { $0 != lead }.prefix(limit))
     }
@@ -295,6 +326,136 @@ private func sourceOrderedFactSentences(
         return Array(afterLead.prefix(limit))
     }
     return Array(sentences.filter { $0 != lead }.prefix(limit))
+}
+
+private func rankedFactSentences(
+    from unit: RAGUnit,
+    query: String,
+    excluding lead: String,
+    limit: Int
+) -> [String] {
+    let sentences = sourceSentences(from: unit.body)
+        .filter { $0 != lead && !isLowValueSummarySentence($0) }
+    guard !sentences.isEmpty else { return [] }
+
+    let matches = rankedSentenceMatches(
+        sentences: sentences,
+        queryTokens: summaryFocusTokens(for: query),
+        objectiveTokens: summaryObjectiveTokens(for: unit),
+        excluding: lead
+    )
+    let relevant = matches
+        .filter { $0.queryOverlap > 0 || $0.objectiveOverlap > 0 || $0.supportCue }
+        .prefix(limit)
+        .map(\.sentence)
+    if !relevant.isEmpty {
+        return Array(relevant)
+    }
+    return Array(sentences.prefix(limit))
+}
+
+private func prefersRankedSummary(for query: String) -> Bool {
+    let lower = query.lowercased()
+    let tokens = Set(BM25Tokenizer.tokenize(query))
+    let diagnosticTokens: Set<String> = [
+        "why", "slow", "sluggish", "lag", "laggy", "weak", "poor", "bad",
+        "issue", "issues", "problem", "problems", "trouble", "troubleshoot",
+        "dropping", "disconnecting", "buffering",
+    ]
+    return !tokens.intersection(diagnosticTokens).isEmpty ||
+        lower.contains("not working")
+}
+
+private struct SummarySentenceMatch {
+    let sentence: String
+    let score: Double
+    let queryOverlap: Int
+    let objectiveOverlap: Int
+    let supportCue: Bool
+}
+
+private func rankedSentenceMatches(
+    sentences: [String],
+    queryTokens: Set<String>,
+    objectiveTokens: Set<String>,
+    excluding: String?
+) -> [SummarySentenceMatch] {
+    sentences.enumerated().compactMap { index, sentence in
+        guard sentence != excluding else { return nil }
+        let sentenceTokens = Set(BM25Tokenizer.tokenize(sentence))
+        let queryOverlap = sentenceTokens.intersection(queryTokens).count
+        let objectiveOverlap = sentenceTokens.intersection(objectiveTokens).count
+        let supportCue = hasSupportCue(sentence)
+        var score = Double(queryOverlap * 4 + objectiveOverlap)
+        if supportCue { score += 1.5 }
+        score -= Double(index) * 0.01
+        return SummarySentenceMatch(
+            sentence: sentence,
+            score: score,
+            queryOverlap: queryOverlap,
+            objectiveOverlap: objectiveOverlap,
+            supportCue: supportCue
+        )
+    }
+    .sorted {
+        if $0.score != $1.score { return $0.score > $1.score }
+        return $0.sentence < $1.sentence
+    }
+}
+
+private func summaryObjectiveTokens(for unit: RAGUnit) -> Set<String> {
+    var tokens = Set(BM25Tokenizer.tokenize(unit.title))
+    for token in BM25Tokenizer.tokenize(unit.displayLabel) { tokens.insert(token) }
+    if let taskID = unit.taskID {
+        for token in BM25Tokenizer.tokenize(taskID) { tokens.insert(token) }
+    }
+    for alias in unit.aliases {
+        for token in BM25Tokenizer.tokenize(alias) { tokens.insert(token) }
+    }
+    return expandWifiTokens(tokens)
+}
+
+private func summaryFocusTokens(for query: String) -> Set<String> {
+    var tokens = Set(BM25Tokenizer.tokenize(query))
+    let lower = query.lowercased()
+    if lower.contains("slow") || lower.contains("sluggish") || lower.contains("lag") {
+        tokens.formUnion([
+            "speed", "performance", "coverage", "reliability", "weak", "fair",
+            "recommended", "action", "repair", "restart", "reset", "optimize",
+            "optimization", "son", "band", "6", "ghz",
+        ])
+    }
+    if lower.contains("why") {
+        tokens.formUnion(["score", "summary", "coverage", "reliability"])
+    }
+    return expandWifiTokens(tokens)
+}
+
+private func expandWifiTokens(_ tokens: Set<String>) -> Set<String> {
+    var expanded = tokens
+    if tokens.contains("wifi") || tokens.contains("wi") || tokens.contains("fi") {
+        expanded.formUnion(["wifi", "wi", "fi", "network", "wireless"])
+    }
+    return expanded
+}
+
+private func isLowValueSummarySentence(_ sentence: String) -> Bool {
+    let normalized = sentence
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+    return normalized == "this page updates hourly" ||
+        normalized == "level 1" ||
+        normalized.hasPrefix("deep link:")
+}
+
+private func hasSupportCue(_ sentence: String) -> Bool {
+    let tokens = Set(BM25Tokenizer.tokenize(sentence))
+    let cues: Set<String> = [
+        "recommended", "action", "improve", "speed", "coverage", "reliability",
+        "weak", "fair", "repair", "restart", "reset", "optimize", "optimization",
+        "connectivity", "issue",
+    ]
+    return !tokens.intersection(cues).isEmpty
 }
 
 private func sourceSentences(from body: String) -> [String] {

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/TelcoChatDispatcher.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/TelcoChatDispatcher.swift
@@ -851,28 +851,10 @@ public actor TelcoChatDispatcher {
             )
         }
 
-        // ---- Retrieve (BM25 hierarchy, state-conditioned) ----
-        // Retrieval runs on every turn — it is sub-millisecond and
-        // side-effect-free — so the policy owner can see evidence
-        // availability before deciding. This unifies what used to be a
-        // pre-retrieval and a post-retrieval policy split (ADR-029 §1).
-        continuation.yield(.retrievalStarted)
-        let history: [ConversationTurnSnippet] = retrievalContext.priorAssistantText.map {
-            [ConversationTurnSnippet(role: "ASSISTANT", body: $0)]
-        } ?? []
-        let retrievalStart = CFAbsoluteTimeGetCurrent()
-        let hits = lexicalRetriever.rank(query: query, context: retrievalContext, k: 3)
-        let retrievalMs = elapsed(retrievalStart)
-        let topUnit = hits.first.flatMap { corpus.unit(forPageID: $0.pageID) }
-        let retrievalCandidates = hits.map {
-            TelcoRetrievalCandidate(pageID: $0.pageID, linkID: $0.linkID, score: $0.score)
-        }
-
         // ---- Resolve the explicit dialogue-state operation (ADR-029 §7) ----
-        // Computed before the route policy so it is authoritative AND serialized
-        // onto the harness report. Retrieval already ran above (sub-ms,
-        // side-effect-free); the operation's retrieval strategy governs whether
-        // the policy reuses the active task's prior evidence vs the fresh top hit.
+        // Computed before retrieval so the data-access layer obeys the state
+        // decision: fresh turns do not inherit stale page/link bias, step-focus
+        // turns do, and ambiguous/repair turns can reuse the active evidence.
         let routePolicyStart = CFAbsoluteTimeGetCurrent()
         let prior = TelcoDeterministicPrior.derive(query: query)
         let stateResolution = TelcoStateOperationResolver.resolve(
@@ -881,6 +863,27 @@ public actor TelcoChatDispatcher {
             prior: prior,
             state: policyState
         )
+
+        // ---- Retrieve (BM25 hierarchy, operation-conditioned) ----
+        // Retrieval is still cheap and side-effect-free, but the context it sees
+        // is now selected by the explicit state operation rather than by whatever
+        // happened to be cached from the prior assistant turn.
+        continuation.yield(.retrievalStarted)
+        let effectiveRetrievalContext = retrievalContextForStrategy(
+            stateResolution.retrieval,
+            original: retrievalContext
+        )
+        let history: [ConversationTurnSnippet] = effectiveRetrievalContext.priorAssistantText.map {
+            [ConversationTurnSnippet(role: "ASSISTANT", body: $0)]
+        } ?? []
+        let retrievalStart = CFAbsoluteTimeGetCurrent()
+        let hits = lexicalRetriever.rank(query: query, context: effectiveRetrievalContext, k: 3)
+        let retrievalMs = elapsed(retrievalStart)
+        let topUnit = hits.first.flatMap { corpus.unit(forPageID: $0.pageID) }
+        let retrievalCandidates = hits.map {
+            TelcoRetrievalCandidate(pageID: $0.pageID, linkID: $0.linkID, score: $0.score)
+        }
+
         let signals = TelcoPolicySignals(
             query: query,
             relation: turnRelation,
@@ -1006,6 +1009,18 @@ public actor TelcoChatDispatcher {
         return topUnit
     }
 
+    private nonisolated func retrievalContextForStrategy(
+        _ strategy: TelcoRetrievalStrategy,
+        original: RetrievalContext
+    ) -> RetrievalContext {
+        switch strategy {
+        case .fresh, .none:
+            return .empty
+        case .priorBias, .reusePrior:
+            return original
+        }
+    }
+
     /// Bridge older dispatcher callers that only carry `RetrievalContext` into
     /// the current policy-engine state contract. The live ChatViewModel passes a
     /// full blackboard snapshot; tests and compatibility callers often only know
@@ -1057,6 +1072,12 @@ public actor TelcoChatDispatcher {
         if ConversationStateRecorder.isLiveAgentRequest(query) {
             return .escalationRequest
         }
+        if ConversationStateRecorder.isContextualActionRequest(query) {
+            return policyState.pendingToolID == nil ? .ambiguousShortTurn : .confirmationYes
+        }
+        if ConversationStateRecorder.isGenericHelpRequest(query) {
+            return .ambiguousShortTurn
+        }
         if ConversationStateRecorder.isBareAffirmative(query) {
             return policyState.pendingToolID == nil ? .ambiguousShortTurn : .confirmationYes
         }
@@ -1068,7 +1089,14 @@ public actor TelcoChatDispatcher {
         }
 
         let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalized.contains("can't find") || normalized.contains("cannot find") {
+        if normalized.contains("can't find")
+            || normalized.contains("cant find")
+            || normalized.contains("cannot find")
+            || normalized.contains("can not find")
+            || normalized.contains("couldn't find")
+            || normalized.contains("couldnt find")
+            || normalized.contains("unable to find")
+            || normalized.contains("not able to find") {
             return .repairCannotFind
         }
         if hasTopicSwitchPrefix(query) {

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/TelcoPolicyEngine.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/TelcoPolicyEngine.swift
@@ -198,14 +198,45 @@ public enum TelcoPolicyEngine {
             // Ambiguous continuation of an active task → reuse its evidence
             // rather than re-retrieving on an under-specified turn.
             if state.hasActiveTask {
+                if ConversationStateRecorder.isContextualActionRequest(signals.query),
+                   let intent = registeredToolIntent(
+                       forLinkID: state.priorLinkID,
+                       toolRegistry: toolRegistry,
+                       aliasMap: aliasMap
+                   ) {
+                    return activeToolActionResolution(
+                        intent: intent,
+                        reuseActiveEvidence: true,
+                        reason: "contextual_action_request"
+                    )
+                }
                 return reuseEvidenceResolution(reason: "reuse_active_evidence")
             }
             // Defensive: the resolver only emits this with an active task; fall
             // through to grounding if state drifted.
 
+        case .confirmationYes:
+            // Typed confirmation should normally be recovered by ChatViewModel
+            // before the composer pipeline. If it reaches the policy owner, the
+            // same ToolRegistry gate still applies and prevents accidental tool
+            // manufacture.
+            guard let pendingToolID = state.pendingToolID else { break }
+            if let intent = registeredToolIntent(
+                forToolOrLinkID: pendingToolID,
+                toolRegistry: toolRegistry,
+                aliasMap: aliasMap
+            ) {
+                return activeToolActionResolution(
+                    intent: intent,
+                    reuseActiveEvidence: state.hasActiveTask,
+                    reason: "confirmation_yes"
+                )
+            }
+            break
+
         case .carryoverActiveTask, .retrieveWithPriorBias, .retrieveFresh,
              .updateNewTask, .clearContextTopicSwitch, .clarificationAnswer,
-             .confirmationYes, .confirmationNo:
+             .confirmationNo:
             // Grounding operations — the retrieval strategy already shaped the
             // evidence upstream; fall through to the greeting / soft-head /
             // scope / grounded rungs below.
@@ -225,6 +256,9 @@ public enum TelcoPolicyEngine {
         // of these back to a hard preempt once the corresponding head is
         // recalibrated (ADR-029 §6 / ADR-028 retrain).
         if !hasGroundableAnswer, let understanding {
+            if understanding.routingLane.isConfident(.blocked) {
+                return .terminal(.outOfScope, handoff: nil, reason: "head_blocked_no_grounding")
+            }
             if understanding.supportIntent.isConfident(.agentHandoff)
                 || understanding.routingLane.isConfident(.humanEscalation)
                 || understanding.issueComplexity.isConfident(.humanRequired)
@@ -312,6 +346,21 @@ public enum TelcoPolicyEngine {
         )
     }
 
+    private static func activeToolActionResolution(
+        intent: ToolIntent,
+        reuseActiveEvidence: Bool,
+        reason: String
+    ) -> TelcoPolicyResolution {
+        TelcoPolicyResolution(
+            route: .toolAction,
+            requiresConfirmation: intent.requiresConfirmation,
+            executableToolIntent: intent,
+            handoff: nil,
+            reuseActiveEvidence: reuseActiveEvidence,
+            reason: reason
+        )
+    }
+
     /// Whether the selected unit lexically covers enough of the query's content
     /// tokens to count as a real local answer. This is the corroboration veto
     /// for the out-of-scope scope-risk signal (Tier C.5) — it is consulted
@@ -352,36 +401,35 @@ public enum TelcoPolicyEngine {
 
         // Resolve the registered tool behind this unit (alias-map first, then
         // the legacy direct link_id == tool_id path for unmapped contexts).
-        var tool: Tool?
-        var imperativeOnly = false
-        if let aliasMap, let alias = aliasMap.alias(forLinkID: unit.linkID) {
-            if let intent = ToolIntent(toolID: alias.toolID) {
-                tool = toolRegistry.tool(for: intent)
-                imperativeOnly = alias.imperativeOnly
-            }
-        } else if let intent = ToolIntent(toolID: unit.linkID) {
-            tool = toolRegistry.tool(for: intent)
-        }
-        guard let resolvedTool = tool,
-              let resolvedIntent = ToolIntent(toolID: resolvedTool.id) else {
+        guard let resolvedIntent = registeredToolIntent(
+            forLinkID: unit.linkID,
+            toolRegistry: toolRegistry,
+            aliasMap: aliasMap
+        ) else {
             // No executable capability → grounded answer only.
             return .grounded(.ragAnswer)
+        }
+        let imperativeOnly = aliasMap?.alias(forLinkID: unit.linkID)?.imperativeOnly == true
+
+        if ConversationStateRecorder.isContextualActionRequest(query), state.hasActiveTask {
+            return .tool(.toolAction, intent: resolvedIntent)
         }
 
         let mood = inferQueryMood(query)
 
         // Gated head evidence (ADR-029 §2). A confident `local_answer` suppresses
         // the action offer. A confident `local_tool` forces the tool action, but
-        // only when corroborated — either the turn's structural mood expresses
-        // action intent, or there is an active tool flow on this task (a pending
-        // confirmation already in play). An action lane on a fresh passive
-        // statement ("connection issues") is a head false positive and must not
-        // manufacture a side-effecting tool offer.
+        // only when the CURRENT turn's structural mood expresses action intent.
+        // A pending confirmation is handled by the explicit `confirmationYes`
+        // state operation above; it is not action intent for unrelated follow-up
+        // questions. An action lane on a fresh passive statement ("connection
+        // issues") is a head false positive and must not manufacture a
+        // side-effecting tool offer.
         if understanding?.routingLane.isConfident(.localAnswer) == true {
             return .grounded(.ragAnswer)
         }
         if understanding?.routingLane.isConfident(.localTool) == true,
-           mood == .actionImperative || state.pendingToolID != nil {
+           mood == .actionImperative {
             return .tool(.toolAction, intent: resolvedIntent)
         }
 
@@ -402,6 +450,39 @@ public enum TelcoPolicyEngine {
         case .navigateImperative, .statement:
             return .grounded(.ragAnswer)
         }
+    }
+
+    private static func registeredToolIntent(
+        forLinkID linkID: String?,
+        toolRegistry: ToolRegistry,
+        aliasMap: ToolAliasMap?
+    ) -> ToolIntent? {
+        let intent: ToolIntent?
+        if let alias = aliasMap?.alias(forLinkID: linkID) {
+            intent = ToolIntent(toolID: alias.toolID)
+        } else if let linkID {
+            intent = ToolIntent(toolID: linkID)
+        } else {
+            intent = nil
+        }
+        guard let resolved = intent,
+              toolRegistry.tool(for: resolved) != nil else {
+            return nil
+        }
+        return resolved
+    }
+
+    private static func registeredToolIntent(
+        forToolOrLinkID id: String?,
+        toolRegistry: ToolRegistry,
+        aliasMap: ToolAliasMap?
+    ) -> ToolIntent? {
+        if let id,
+           let direct = ToolIntent(toolID: id),
+           toolRegistry.tool(for: direct) != nil {
+            return direct
+        }
+        return registeredToolIntent(forLinkID: id, toolRegistry: toolRegistry, aliasMap: aliasMap)
     }
 }
 

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/TelcoSharedUnderstanding.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/TelcoSharedUnderstanding.swift
@@ -97,10 +97,14 @@ public struct TelcoSharedUnderstanding: Sendable, Equatable {
             cloudRequirements.hasConfidentActiveLabel()
     }
 
-    /// Hard policy: the turn should not go through local RAG/composer.
+    /// Hard policy: payment/identity data must not go through local RAG/composer.
+    ///
+    /// `routing_lane=blocked` is intentionally not included here. ADR-032 keeps
+    /// non-PII routing-lane deflections corroboration-gated until deployment-
+    /// register precision earns HARD trust; the policy engine handles that
+    /// softer signal only when no local evidence grounds the turn.
     public var isBlocked: Bool {
-        routingLane.isConfident(.blocked) ||
-            piiRisk.isConfident(.containsPaymentIdentityData, minimum: TelcoPolicyThreshold.piiBlock)
+        piiRisk.isConfident(.containsPaymentIdentityData, minimum: TelcoPolicyThreshold.piiBlock)
     }
 
     /// Low-quality voice/partial transcript signal. This asks for

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/ConversationState.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/ConversationState.swift
@@ -548,6 +548,31 @@ public enum ConversationStateRecorder {
         ) != nil
     }
 
+    /// True when the user asks for generic help with the current task,
+    /// without naming a new support object. Standalone, these turns are
+    /// under-specified ("Can you help me?"); with an active task they
+    /// continue that task. Explicit person-seeking variants remain
+    /// live-agent requests via `isLiveAgentRequest`.
+    public static func isGenericHelpRequest(_ message: String) -> Bool {
+        let normalized = normalize(message)
+        return genericHelpPatterns.firstMatch(
+            in: normalized,
+            range: NSRange(normalized.startIndex..., in: normalized)
+        ) != nil
+    }
+
+    /// True when the user asks the assistant to perform the active task using
+    /// a pronoun ("it"/"this"/"that") rather than naming a new task. These
+    /// turns are only meaningful with dialogue state; the policy layer still
+    /// requires a registered tool before routing to execution.
+    public static func isContextualActionRequest(_ message: String) -> Bool {
+        let normalized = normalize(message)
+        return contextualActionPatterns.firstMatch(
+            in: normalized,
+            range: NSRange(normalized.startIndex..., in: normalized)
+        ) != nil
+    }
+
     /// True when the user message is a bare affirmative ("yes", "yep",
     /// "go ahead", "do it"). Used by the pending-clarification path to
     /// recognise "yes" as "confirm the previous proposal" rather than
@@ -623,6 +648,46 @@ public enum ConversationStateRecorder {
         )\b
         """#,
         options: [.allowCommentsAndWhitespace]
+    )
+
+    /// Generic help requests that contain no new object ("router",
+    /// "Wi-Fi", "password", etc.). These are dialogue acts, not search
+    /// queries. Do not add "someone/agent/person" here; those belong
+    /// to the live-agent lexicon above.
+    // swiftlint:disable:next force_try
+    private static let genericHelpPatterns: NSRegularExpression = try! NSRegularExpression(
+        pattern: #"""
+        ^\s*(?:
+            (?:(?:can|could|would|will)\s+you\s+)?(?:please\s+)?help(?:\s+me)?
+                (?:\s+(?:with\s+)?(?:this|that|it|the\s+steps?))?
+          | (?:i\s+)?need\s+(?:some\s+)?help
+                (?:\s+(?:with\s+)?(?:this|that|it|the\s+steps?))?
+          | (?:(?:can|could|would|will)\s+you\s+)?(?:please\s+)?
+                (?:(?:walk\s+me\s+through)|(?:guide\s+me))
+                (?:\s+(?:this|that|it|the\s+steps?))?
+          | (?:what\s+now|now\s+what)
+        )\s*[?.!]?\s*$
+        """#,
+        options: [.allowCommentsAndWhitespace, .caseInsensitive]
+    )
+
+    /// Pronoun-based requests to perform the active task. Excludes "how do I
+    /// do it" / "tell me how to do it" because those are informational, not
+    /// execution requests.
+    // swiftlint:disable:next force_try
+    private static let contextualActionPatterns: NSRegularExpression = try! NSRegularExpression(
+        pattern: #"""
+        ^\s*(?:
+            (?:(?:can|could|would|will)\s+you\s+)?
+                (?:(?:do|perform|handle|run|start|take\s+care\s+of)\s+(?:it|this|that))
+                (?:\s+for\s+me)?
+          | (?:please\s+)?(?:do|perform|handle|run|start)\s+(?:it|this|that)
+                (?:\s+for\s+me)?
+          | (?:please\s+)?(?:take\s+care\s+of)\s+(?:it|this|that)
+                (?:\s+for\s+me)?
+        )\s*[?.!]?\s*$
+        """#,
+        options: [.allowCommentsAndWhitespace, .caseInsensitive]
     )
 
     /// Bare affirmatives. Tight on purpose — "yes please send it" is

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/TelcoDialogueBlackboard.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/TelcoDialogueBlackboard.swift
@@ -191,7 +191,8 @@ public enum TelcoDialogueBlackboardReducer {
         next.lastRetrievalCandidates = retrievalCandidates
         next.lastPolicyDecision = policyDecision ?? next.lastPolicyDecision
 
-        let relation = observedRelation ?? fallbackRelation(for: userTurn, blackboard: blackboard)
+        let rawRelation = observedRelation ?? fallbackRelation(for: userTurn, blackboard: blackboard)
+        let relation = normalizeRelation(rawRelation, for: userTurn)
         next.lastTurnRelation = relation
         next.auditTrail.append(event(next, .userTurn, "chat", "record_user_turn", now))
         if observedRelation == nil {
@@ -357,6 +358,12 @@ public enum TelcoDialogueBlackboardReducer {
         if ConversationStateRecorder.isDidntWorkContinuation(userTurn) {
             return .repairFailed
         }
+        if ConversationStateRecorder.isContextualActionRequest(userTurn) {
+            return blackboard.pendingToolConfirmation == nil ? .ambiguousShortTurn : .confirmationYes
+        }
+        if ConversationStateRecorder.isGenericHelpRequest(userTurn) {
+            return .ambiguousShortTurn
+        }
         if normalized.contains("can't find") || normalized.contains("cannot find") {
             return .repairCannotFind
         }
@@ -367,6 +374,19 @@ public enum TelcoDialogueBlackboardReducer {
             return .topicSwitch
         }
         return .independentNewTask
+    }
+
+    private static func normalizeRelation(
+        _ relation: TelcoTurnRelation,
+        for userTurn: String
+    ) -> TelcoTurnRelation {
+        if ConversationStateRecorder.isGenericHelpRequest(userTurn) {
+            return .ambiguousShortTurn
+        }
+        if ConversationStateRecorder.isContextualActionRequest(userTurn) {
+            return .ambiguousShortTurn
+        }
+        return relation
     }
 
     private static func clearActiveState(_ blackboard: inout TelcoDialogueBlackboard) {

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/TelcoStateOperation.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/TelcoStateOperation.swift
@@ -135,13 +135,20 @@ public struct TelcoStateResolution: Sendable, Equatable {
 ///    valid only when a tool confirmation is actually pending — a bare "yes" with
 ///    no pending tool must never execute or confirm.
 /// 8. Topic switch — clear context, retrieve fresh.
-/// 9. Ambiguous short turn — by relation label *or* a structural ≤2 content-token
+/// 9. Contextual action request ("can you do it for me?") — not a search
+///    query. With a pending tool it confirms that tool; with a valid active
+///    task, carry it over (reuse) so the policy can resolve the active tool;
+///    otherwise ask what "it" refers to.
+/// 10. Contextual generic help ("can you help me?") — not a search query. With
+///    a valid active task, carry it over (reuse); otherwise ask for the missing
+///    detail rather than grounding the Help & feedback page.
+/// 11. Ambiguous short turn — by relation label *or* a structural ≤2 content-token
 ///    signal (the same length doctrine the situation overlay uses). With a valid
 ///    active task, carry it over (reuse); otherwise ask for the missing detail
 ///    rather than grounding a fresh page on two words.
-/// 10. Continuation / step-focus — stay on the active task with prior bias, or
+/// 12. Continuation / step-focus — stay on the active task with prior bias, or
 ///     retrieve fresh if there is no active task.
-/// 11. Independent new task (or no relation) — retrieve fresh.
+/// 13. Independent new task (or no relation) — retrieve fresh.
 public enum TelcoStateOperationResolver {
     /// Content-token count at or below which a turn is treated as structurally
     /// ambiguous. Mirrors `situation_eval.classify_situation`'s `ntok <= 2` rule
@@ -240,7 +247,49 @@ public enum TelcoStateOperationResolver {
             )
         }
 
-        // 9. Ambiguous short turn — relation label or structural ≤2-token signal.
+        // 9. Contextual action request — "can you do it for me" is a pronoun
+        //    act over the active task, not a fresh RAG query. The policy layer
+        //    still performs the ToolRegistry gate, so this cannot manufacture a
+        //    tool for pages that do not have one.
+        if ConversationStateRecorder.isContextualActionRequest(query) {
+            if state.pendingToolID != nil {
+                return .init(
+                    operation: .confirmationYes,
+                    retrieval: state.hasActiveTask ? .priorBias : .fresh,
+                    reason: "contextual_action_confirmation"
+                )
+            }
+            if state.hasActiveTask {
+                return .init(
+                    operation: .reuseActiveEvidence,
+                    retrieval: .reusePrior,
+                    reason: "contextual_action_carryover"
+                )
+            }
+            return .init(
+                operation: .askClarification,
+                retrieval: .none,
+                reason: "contextual_action_no_state"
+            )
+        }
+
+        // 10. Generic help with no object — dialogue act, not a Help & feedback
+        //    page search. Carry the active task if one exists; otherwise ask what
+        //    the user wants help with. This is deliberately separate from the
+        //    structural short-turn rule because "can you help me" is four
+        //    whitespace tokens but semantically under-specified.
+        if ConversationStateRecorder.isGenericHelpRequest(query) {
+            if state.hasActiveTask {
+                return .init(
+                    operation: .reuseActiveEvidence,
+                    retrieval: .reusePrior,
+                    reason: "generic_help_carryover"
+                )
+            }
+            return .init(operation: .askClarification, retrieval: .none, reason: "generic_help_no_state")
+        }
+
+        // 11. Ambiguous short turn — relation label or structural ≤2-token signal.
         if relation == .ambiguousShortTurn || isStructurallyShort(query) {
             if state.hasActiveTask {
                 return .init(
@@ -250,7 +299,7 @@ public enum TelcoStateOperationResolver {
             return .init(operation: .askClarification, retrieval: .none, reason: "ambiguous_no_state")
         }
 
-        // 10. Continuation / step-focus — stay on task with prior bias, else fresh.
+        // 12. Continuation / step-focus — stay on task with prior bias, else fresh.
         switch relation {
         case .continuationSameTask, .continuationSameSection:
             return state.hasActiveTask
@@ -269,7 +318,7 @@ public enum TelcoStateOperationResolver {
             break
         }
 
-        // 11. Independent new task, or no relation available.
+        // 13. Independent new task, or no relation available.
         return .init(operation: .updateNewTask, retrieval: .fresh, reason: "independent_new_task")
     }
 

--- a/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/TelcoTurnRelationV4Strategy.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Core/Intelligence/Understanding/TelcoTurnRelationV4Strategy.swift
@@ -184,6 +184,12 @@ public final class TelcoTurnRelationV4Strategy: RelationalHeadsStrategy, @unchec
         if ConversationStateRecorder.isLiveAgentRequest(query) {
             return .escalationRequest
         }
+        if ConversationStateRecorder.isContextualActionRequest(query) {
+            return runtimeState.pendingConfirmation ? .confirmationYes : .ambiguousShortTurn
+        }
+        if ConversationStateRecorder.isGenericHelpRequest(query) {
+            return .ambiguousShortTurn
+        }
         if ConversationStateRecorder.isBareAffirmative(query) {
             return runtimeState.pendingConfirmation ? .confirmationYes : .ambiguousShortTurn
         }

--- a/examples/telco-triage-ios/TelcoTriage/Features/Chat/ChatViewModel.swift
+++ b/examples/telco-triage-ios/TelcoTriage/Features/Chat/ChatViewModel.swift
@@ -335,7 +335,8 @@ final class ChatViewModel: ObservableObject {
         // friction — missing the clarification entirely costs the
         // whole flow.
         if let pendingConfirmation = conversationState.pendingToolConfirmation,
-           ConversationStateRecorder.isBareAffirmative(query) {
+           (ConversationStateRecorder.isBareAffirmative(query)
+            || ConversationStateRecorder.isContextualActionRequest(query)) {
             let priorUserText = previousUserTurnText()
             let (turnRelation, _) = await classifyTelcoTurnRelation(
                 query,
@@ -422,6 +423,8 @@ final class ChatViewModel: ObservableObject {
             )
             return
         }
+
+        clearPendingToolConfirmationIfSuperseded(by: query)
 
         if let pending = conversationState.pendingClarification,
            let recovery = tryFulfillPendingClarification(
@@ -1223,6 +1226,26 @@ final class ChatViewModel: ObservableObject {
             assistantText,
             on: dialogueBlackboard
         )
+    }
+
+    private func clearPendingToolConfirmationIfSuperseded(by query: String) {
+        guard conversationState.pendingToolConfirmation != nil
+            || dialogueBlackboard.pendingToolConfirmation != nil else {
+            return
+        }
+        if ConversationStateRecorder.isBareAffirmative(query)
+            || ConversationStateRecorder.isBareNegative(query)
+            || ConversationStateRecorder.isContextualActionRequest(query) {
+            return
+        }
+        AppLog.intelligence.info("pending-tool-confirmation cleared (superseded by new turn)")
+        conversationState.clearPendingToolConfirmation()
+        if dialogueBlackboard.pendingToolConfirmation != nil {
+            dialogueBlackboard = TelcoDialogueBlackboardReducer.recordToolCancelled(
+                on: dialogueBlackboard,
+                reasonCode: "superseded_by_new_turn"
+            )
+        }
     }
 
     private func runGroundedQA(

--- a/examples/telco-triage-ios/TelcoTriageTests/TelcoDispatcherComposerPathTests.swift
+++ b/examples/telco-triage-ios/TelcoTriageTests/TelcoDispatcherComposerPathTests.swift
@@ -345,7 +345,7 @@ final class TelcoDispatcherComposerPathTests: XCTestCase {
         XCTAssertEqual(seenInput?.conversationState.priorPageID, "02.07")
     }
 
-    func test_dialogueRepairV4KeepsToolConfirmationOwnedByDispatcher() async {
+    func test_dialogueRepairV4CannotPromotePendingToolWithoutExplicitAction() async {
         let verbalizer = StubDialogueRepairVerbalizer(text: "I can try restarting the router from here.")
         let understanding = makeTelcoUnderstanding(
             routingLane: .localTool,
@@ -372,12 +372,12 @@ final class TelcoDispatcherComposerPathTests: XCTestCase {
         )
 
         XCTAssertEqual(result.source, .dialogueRepair)
-        XCTAssertEqual(result.composerRoute, .toolAction)
-        XCTAssertEqual(result.requiresConfirmation, true)
-        XCTAssertEqual(result.executableToolIntent, .restartRouter)
-        XCTAssertTrue(
+        XCTAssertEqual(result.composerRoute, .ragAnswer)
+        XCTAssertEqual(result.requiresConfirmation, false)
+        XCTAssertNil(result.executableToolIntent)
+        XCTAssertFalse(
             result.text.contains("Reply 'yes' to confirm."),
-            "Swift owns the confirmation clause even when V4 verbalizes the repair text"
+            "Pending tool state must not promote a repair turn into a tool confirmation"
         )
     }
 


### PR DESCRIPTION
## Summary
- port the generic telco dialogue-routing fixes into the cookbook iOS app
- separate pending tool state from action intent so unrelated follow-up questions do not execute stale tools
- resolve state before retrieval so generic help/contextual action turns reuse or clear context intentionally
- improve grounded answer composition and keep blocked lanes soft when local grounding is available

## Verification
- git diff --check
- xcodebuild test -project TelcoTriage.xcodeproj -scheme TelcoTriage -destination 'id=DA4B397B-C669-4F20-A851-8A1FD7053E4F'