### PR TITLE
Add react-native-leap to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Open-source projects built by the community showcasing LFMs with real use cases.
 | barq-web-rag | Browser-based RAG app for document Q&A with LFM2.5-1.2B-Thinking running fully local via WebGPU | [Code](https://github.com/YASSERRMD/barq-web-rag) |
 | Tauri Plugin LEAP AI | Tauri plugin to integrate LEAP and Liquid LFMs into desktop and mobile apps | [Crate](https://crates.io/crates/tauri-plugin-leap-ai) |
 | Chat with LEAP SDK | LEAP SDK integration for React Native | [Code](https://github.com/glody007/expo-leap-sdk) |
+| react-native-leap | React Native & Expo bindings for the LEAP SDK via Nitro Modules — streaming chat, constrained JSON (Zod), tool calling, vision, voice, and a Vercel AI SDK provider | [Code](https://github.com/hung-yueh/react-native-leap) |
 
 ### End-to-End Projects
 


### PR DESCRIPTION
## What

Adds **[react-native-leap](https://github.com/hung-yueh/react-native-leap)** to the Community Projects → Deployment table: React Native & Expo bindings for the LEAP SDK (current 0.10.x KMP generation) via [Nitro Modules](https://nitro.margelo.com/).

On npm as [`react-native-leap`](https://www.npmjs.com/package/react-native-leap), MIT-licensed. Feature coverage, all validated end-to-end on a physical iPhone and the Android emulator:

- Streaming chat with typed events and per-generation stats (tok/s, KV-cache hits)
- Grammar-constrained JSON at the token level, from a Zod v4 schema or raw JSON Schema
- Tool calling with an automatic model↔tool loop
- Thinking models (separate reasoning stream), vision (LFM2.5-VL), and voice (LFM2.5-Audio speech-to-speech with streamed PCM + captions)
- Model management via the LEAP model library (download progress, memory pre-flight) or sideloaded GGUFs
- A Vercel AI SDK provider, [`@react-native-leap/ai`](https://www.npmjs.com/package/@react-native-leap/ai), so LEAP models work with `streamText` / `generateObject` from the `ai` package
- Expo config plugin for prebuild / dev-client workflows

LEAP binaries are not re-hosted: iOS fetches Liquid's official XCFramework release at install time (SHA-256-verified), Android pulls `ai.liquid.leap:*` from Maven Central.

Placed next to the existing React Native entry (expo-leap-sdk, which targets the legacy 0.9 iOS/Android SDKs); this one wraps the unified 0.10.x SDK.